### PR TITLE
fix: use AuthStorage in web tools, add null-safety for model details

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,31 @@ on:
       - "v*"
 
 jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install pi
+        run: npm install -g @mariozechner/pi-coding-agent
+
+      - name: Smoke test
+        env:
+          OLLAMA_API_KEY: ${{ secrets.OLLAMA_CLOUD_API_KEY }}
+        run: pi --extension ./index.ts --model "ollama-cloud/gemma4:31b" --no-tools -p "Say hi in one word"
+
   publish:
+    needs: smoke
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,35 @@
+name: Smoke Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    environment: ollama-cloud
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install pi
+        run: npm install -g @mariozechner/pi-coding-agent
+
+      - name: Install extension locally
+        run: pi install ./
+
+      - name: Smoke test
+        env:
+          OLLAMA_API_KEY: ${{ secrets.OLLAMA_CLOUD_API_KEY }}
+        run: pi -m "gemma4:cloud" --no-tools -p "Say hi in one word"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -26,10 +26,7 @@ jobs:
       - name: Install pi
         run: npm install -g @mariozechner/pi-coding-agent
 
-      - name: Install extension locally
-        run: pi install ./
-
       - name: Smoke test
         env:
           OLLAMA_API_KEY: ${{ secrets.OLLAMA_CLOUD_API_KEY }}
-        run: pi -m "gemma4:cloud" --no-tools -p "Say hi in one word"
+        run: pi --extension ./index.ts --model "gemma4:cloud" --no-tools -p "Say hi in one word"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   smoke:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Smoke test
         env:
           OLLAMA_API_KEY: ${{ secrets.OLLAMA_CLOUD_API_KEY }}
-        run: pi --extension ./index.ts --model "gemma4:cloud" --no-tools -p "Say hi in one word"
+        run: pi --extension ./index.ts --model "ollama-cloud/gemma4:31b" --no-tools -p "Say hi in one word"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   smoke:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   smoke:
     runs-on: ubuntu-latest
-    environment: ollama-cloud
     steps:
       - uses: actions/checkout@v6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.1] - 2026-05-05
+
+- Fix `OLLAMA_API_KEY` env var not being respected by `fetchModels` and web tools. pi-ai does not know about the `ollama-cloud` provider ID, so `AuthStorage.getApiKey()` alone misses the env var. Added explicit `process.env.OLLAMA_API_KEY` fallback.
+- Switch web tools to `AuthStorage.create()` for API key lookup, matching the `models.ts` auth pattern from v0.2.1.
+- Add null-safe access to `data.details?.family` in `resolveThinkingLevelMap`.
+- Change `OLLAMA_BASE` from `export let` to `export const` to prevent accidental mutation.
+- Fix fallback model IDs to use real Ollama Cloud identifiers (`glm-5.1`, `gemma4:31b`) instead of synthetic `:cloud` suffixes.
+- Add smoke test workflow for CI.
+
 ## [0.3.0] - 2026-05-04
 
 - Derive `thinkingLevelMap` from pi's built-in model definitions instead of hardcoding model-family mappings. The extension now picks up thinking level metadata automatically when pi-mono adds or updates it for any model.

--- a/models.ts
+++ b/models.ts
@@ -87,9 +87,11 @@ function resolveThinkingLevelMap(modelId: string, data: OllamaShowResponse): Pro
   // 2. Family-based fallback: match Ollama's details.family against pi model stems
   if (data.capabilities?.includes("thinking")) {
     const familyStem = data.details?.family?.replace(/[^a-zA-Z0-9]/g, "").toLowerCase() ?? "";
-    for (const [stem, tlm] of BUILTIN_FAMILY_ENTRIES) {
-      if (stem.startsWith(familyStem)) {
-        return tlm;
+    if (familyStem) {
+      for (const [stem, tlm] of BUILTIN_FAMILY_ENTRIES) {
+        if (stem.startsWith(familyStem)) {
+          return tlm;
+        }
       }
     }
   }

--- a/models.ts
+++ b/models.ts
@@ -1,8 +1,12 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { type ExtensionCommandContext, getAgentDir, type ProviderModelConfig } from "@mariozechner/pi-coding-agent";
-import { AuthStorage } from "@mariozechner/pi-coding-agent";
 import { getModels, getProviders } from "@mariozechner/pi-ai";
+import {
+  AuthStorage,
+  type ExtensionCommandContext,
+  getAgentDir,
+  type ProviderModelConfig,
+} from "@mariozechner/pi-coding-agent";
 
 // --- Constants ---
 const CACHE_DIR = join(getAgentDir(), "cache");
@@ -10,7 +14,7 @@ const CACHE_FILE = join(CACHE_DIR, "ollama-cloud-models.json");
 const FETCH_TIMEOUT_MS = 10000;
 
 // --- API fetch ---
-export let OLLAMA_BASE = (process.env.OLLAMA_API_BASE || "https://ollama.com").replace(/\/+$/, "");
+export const OLLAMA_BASE = (process.env.OLLAMA_API_BASE || "https://ollama.com").replace(/\/+$/, "");
 
 // Initialize AuthStorage
 const authStorage = AuthStorage.create();
@@ -82,7 +86,7 @@ function resolveThinkingLevelMap(modelId: string, data: OllamaShowResponse): Pro
 
   // 2. Family-based fallback: match Ollama's details.family against pi model stems
   if (data.capabilities?.includes("thinking")) {
-    const familyStem = data.details.family.replace(/[^a-zA-Z0-9]/g, "").toLowerCase();
+    const familyStem = data.details?.family?.replace(/[^a-zA-Z0-9]/g, "").toLowerCase() ?? "";
     for (const [stem, tlm] of BUILTIN_FAMILY_ENTRIES) {
       if (stem.startsWith(familyStem)) {
         return tlm;
@@ -162,7 +166,7 @@ export async function fetchModels(ctx: ExtensionCommandContext): Promise<Record<
         "- auth.json file (at ~/.pi/agent/auth.json) under 'ollama-cloud' key,\n" +
         "- or via the CLI --api-key flag.\n" +
         "Example auth.json entry: \n" +
-        '{ \"ollama-cloud\": { \"type\": \"api_key\", \"key\": \"YOUR_API_KEY\" } }',
+        '{ "ollama-cloud": { "type": "api_key", "key": "YOUR_API_KEY" } }',
       "error",
     );
     return null;

--- a/models.ts
+++ b/models.ts
@@ -115,18 +115,18 @@ export function assembleModels(raw: Record<string, OllamaShowResponse>): Provide
 // --- Fallback models (cold cache) ---
 export const FALLBACK_MODELS: ProviderModelConfig[] = [
   {
-    id: "glm-5.1:cloud",
-    name: "GLM 5.1 Cloud",
-    reasoning: true,
+    id: "glm-5.1",
+    name: "GLM 5.1",
+    reasoning: false,
     input: ["text"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 202752,
     maxTokens: 32768,
   },
   {
-    id: "gemma4:cloud",
-    name: "Gemma 4 Cloud",
-    reasoning: true,
+    id: "gemma4:31b",
+    name: "Gemma 4 31B",
+    reasoning: false,
     input: ["text"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 262144,

--- a/models.ts
+++ b/models.ts
@@ -157,7 +157,7 @@ export function writeCache(models: Record<string, OllamaShowResponse>): void {
 
 // --- Fetch Models ---
 export async function fetchModels(ctx: ExtensionCommandContext): Promise<Record<string, OllamaShowResponse> | null> {
-  const apiKey = await authStorage.getApiKey("ollama-cloud");
+  const apiKey = (await authStorage.getApiKey("ollama-cloud")) ?? process.env.OLLAMA_API_KEY;
 
   if (!apiKey) {
     ctx.ui.notify(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-ollama-cloud",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-ollama-cloud",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "devDependencies": {
         "@biomejs/biome": "2"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-ollama-cloud",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "keywords": [
     "pi-package"

--- a/web-tools.ts
+++ b/web-tools.ts
@@ -24,7 +24,7 @@ interface FetchResponse {
 const authStorage = AuthStorage.create();
 
 async function getCloudApiKey(): Promise<string | undefined> {
-  return authStorage.getApiKey("ollama-cloud");
+  return authStorage.getApiKey("ollama-cloud") ?? process.env.OLLAMA_API_KEY;
 }
 
 function noApiKeyError() {

--- a/web-tools.ts
+++ b/web-tools.ts
@@ -1,9 +1,4 @@
-import {
-  type ExtensionAPI,
-  type ExtensionContext,
-  keyHint,
-  truncateToVisualLines,
-} from "@mariozechner/pi-coding-agent";
+import { AuthStorage, type ExtensionAPI, keyHint, truncateToVisualLines } from "@mariozechner/pi-coding-agent";
 import { Text, truncateToWidth } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { OLLAMA_BASE } from "./models.ts";
@@ -26,8 +21,10 @@ interface FetchResponse {
 
 // --- Helpers ---
 
-async function getCloudApiKey(ctx: ExtensionContext): Promise<string | undefined> {
-  return ctx.modelRegistry.getApiKeyForProvider("ollama-cloud");
+const authStorage = AuthStorage.create();
+
+async function getCloudApiKey(): Promise<string | undefined> {
+  return authStorage.getApiKey("ollama-cloud");
 }
 
 function noApiKeyError() {
@@ -121,8 +118,8 @@ export function registerWebSearchTool(pi: ExtensionAPI) {
         }),
       ),
     }),
-    async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-      const apiKey = await getCloudApiKey(ctx);
+    async execute(_toolCallId, params, signal, _onUpdate, _ctx) {
+      const apiKey = await getCloudApiKey();
       if (!apiKey) return noApiKeyError();
 
       try {
@@ -180,8 +177,8 @@ export function registerWebFetchTool(pi: ExtensionAPI) {
     parameters: Type.Object({
       url: Type.String({ description: "URL to fetch and extract content from", format: "uri" }),
     }),
-    async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-      const apiKey = await getCloudApiKey(ctx);
+    async execute(_toolCallId, params, signal, _onUpdate, _ctx) {
+      const apiKey = await getCloudApiKey();
       if (!apiKey) return noApiKeyError();
 
       try {


### PR DESCRIPTION
## Summary

Consistency and hardening fixes. Web tools now use the same auth path as
`models.ts`, and `OLLAMA_API_KEY` env var is properly respected everywhere.
Fixed fallback model IDs to use real Ollama Cloud identifiers. Adds a
smoke test workflow.

Fixes #4

## Changes

- **web-tools.ts** — Replaced `ctx.modelRegistry.getApiKeyForProvider` with
  `AuthStorage.create().getApiKey`. Added `process.env.OLLAMA_API_KEY` fallback
  since pi-ai does not know about the `ollama-cloud` provider ID.
- **models.ts** — Same `OLLAMA_API_KEY` env var fallback in `fetchModels`.
- **models.ts** — Null-safe access to `data.details?.family` in
  `resolveThinkingLevelMap`.
- **models.ts** — `OLLAMA_BASE` changed from `export let` to `export const`.
- **models.ts** — Fallback models now use real Ollama Cloud model IDs
  (`glm-5.1`, `gemma4:31b`) instead of synthetic `:cloud` suffixes. Set
  `reasoning: false` to avoid an Ollama API casing mismatch with reasoning
  values.
- **.github/workflows/smoke.yml** — Smoke test that loads the extension
  directly and runs a one-shot prompt. Gated to same-repo PRs only.