### PR TITLE
Fix thinking/reasoning support across ollama cloud models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - Add packaged `reasoning-models.json` for curated effective thinking levels instead of treating accepted API values as authoritative.
-- Map Pi `off` to Ollama's OpenAI-compatible `reasoning_effort: "none"` where off is supported, keep GPT-OSS on low/medium/high only, treat Qwen 3.x and most DeepSeek models as binary on/off, and give unknown thinking-capable models a conservative binary `off`/`medium` map.
+- Map Pi `off` to Ollama's OpenAI-compatible `reasoning_effort: "none"` where off is supported, keep GPT-OSS on low/medium/high only, give `deepseek-v4-pro` full granular OpenAI-compatible reasoning efforts, treat Qwen 3.x and most DeepSeek models as binary on/off, and give unknown thinking-capable models a conservative binary `off`/`medium` map.
 - Document how thinking levels are determined and how to refresh the cached model metadata.
 - Treat stale local model caches as usable for immediate startup while triggering the same visible refresh flow as `/ollama-cloud-refresh` on `session_start`; use fallback models only when the cache is missing or invalid.
 - Add a single-line `/ollama-cloud-refresh` progress widget showing the current stage, count, percentage, failures, and progress bar.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - Add packaged `reasoning-models.json` for curated effective thinking levels instead of treating accepted API values as authoritative.
-- Map Pi `off` to Ollama's OpenAI-compatible `reasoning_effort: "none"` where off is supported, keep GPT-OSS on low/medium/high only, give `deepseek-v4-pro` full granular OpenAI-compatible reasoning efforts, treat Qwen 3.x and most DeepSeek models as binary on/off, and give unknown thinking-capable models a conservative binary `off`/`medium` map.
+- Map Pi `off` to Ollama's OpenAI-compatible `reasoning_effort: "none"` where off is supported, keep GPT-OSS on low/medium/high only, treat Qwen 3.x and most DeepSeek models as binary on/off, and give unknown thinking-capable models a conservative binary `off`/`medium` map.
 - Document how thinking levels are determined and how to refresh the cached model metadata.
 - Treat stale local model caches as usable for immediate startup while triggering the same visible refresh flow as `/ollama-cloud-refresh` on `session_start`; use fallback models only when the cache is missing or invalid.
 - Add a single-line `/ollama-cloud-refresh` progress widget showing the current stage, count, percentage, failures, and progress bar.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- Add packaged `reasoning-models.json` for curated effective thinking levels instead of treating accepted API values as authoritative.
+- Map Pi `off` to Ollama's OpenAI-compatible `reasoning_effort: "none"` where off is supported, keep GPT-OSS on low/medium/high only, treat Qwen 3.x and most DeepSeek models as binary on/off, and give unknown thinking-capable models a conservative binary `off`/`medium` map.
+- Document how thinking levels are determined and how to refresh the cached model metadata.
+- Treat stale local model caches as usable for immediate startup while triggering the same visible refresh flow as `/ollama-cloud-refresh` on `session_start`; use fallback models only when the cache is missing or invalid.
+- Add a single-line `/ollama-cloud-refresh` progress widget showing the current stage, count, percentage, failures, and progress bar.
+
 ## [0.3.1] - 2026-05-05
 
 - Fix `OLLAMA_API_KEY` env var not being respected by `fetchModels` and web tools. pi-ai does not know about the `ollama-cloud` provider ID, so `AuthStorage.getApiKey()` alone misses the env var. Added explicit `process.env.OLLAMA_API_KEY` fallback.

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Instead, `reasoning-models.json` curates the levels exposed to Pi, based on Olla
 
 | Model/family | Pi levels exposed | Notes |
 |---|---|---|
-| `deepseek-v4-pro` | `off`, `minimal`, `low`, `medium`, `high`, `xhigh` | Full granular reasoning through Ollama Cloud's OpenAI-compatible `reasoning_effort` values. |
+| `deepseek-v4-pro` | `off`, `minimal`, `low`, `medium`, `high`, `xhigh` | Maps Pi `xhigh` to Ollama `max`. |
 | `gpt-oss*` | `low`, `medium`, `high` | Ollama docs list low/medium/high and no off mode. |
 | `qwen3*` | `off`, `medium` | Qwen 3.x is treated as binary on/off. |
 | `deepseek*` | `off`, `medium` | DeepSeek models are treated as binary on/off unless explicitly overridden. |

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Instead, `reasoning-models.json` curates the levels exposed to Pi, based on Olla
 
 | Model/family | Pi levels exposed | Notes |
 |---|---|---|
-| `deepseek-v4-pro` | `off`, `minimal`, `low`, `medium`, `high`, `xhigh` | Maps Pi `xhigh` to Ollama `max`. |
+| `deepseek-v4-pro` | `off`, `minimal`, `low`, `medium`, `high`, `xhigh` | Full granular reasoning through Ollama Cloud's OpenAI-compatible `reasoning_effort` values. |
 | `gpt-oss*` | `low`, `medium`, `high` | Ollama docs list low/medium/high and no off mode. |
 | `qwen3*` | `off`, `medium` | Qwen 3.x is treated as binary on/off. |
 | `deepseek*` | `off`, `medium` | DeepSeek models are treated as binary on/off unless explicitly overridden. |

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ Registers Ollama Cloud as a model provider with dynamically fetched models, and 
 ## Features
 
 - **Dynamic model discovery** - Fetches the full model list from `ollama.com/v1/models`, then fetches per-model details via `/api/show` to determine capabilities, context length, and tool support.
+- **Curated thinking levels** - Models that advertise the `thinking` capability are mapped through `reasoning-models.json` so Pi only exposes thinking levels known to be effective for that model family.
 - **Persistent cache** - Raw API responses are cached at `~/.pi/agent/cache/ollama-cloud-models.json` so models are available immediately on startup without hitting the network.
-- **Cold cache fallback** - When no cache exists, a small set of hardcoded models is used until `/ollama-cloud-refresh` is run.
-- **`/ollama-cloud-refresh` command** - Re-fetches the model list from the API and updates the cache and provider registration live (no restart needed).
+- **Startup refresh** - When the local cache is stale, the plugin uses it immediately and then runs the same visible refresh flow as `/ollama-cloud-refresh` once the Pi session UI is available. Missing/invalid caches use a small fallback list until refresh completes.
+- **`/ollama-cloud-refresh` command** - Re-fetches the model list and updates the cache and provider registration live (no restart needed).
 - **`ollama_web_search` tool** - Search the web for real-time information using Ollama Cloud's `/api/web_search` endpoint. Returns titles, URLs, and content snippets.
 - **`ollama_web_fetch` tool** - Fetch and extract text content from a web page URL using Ollama Cloud's `/api/web_fetch` endpoint. Returns page title, content, and links.
 - **Zero cost tracking** - All models are registered with zero costs since Ollama Cloud uses a flat subscription model (Free, Pro, Max) rather than per-token billing. Per-request costs don't apply, so Pi's cost tracker always shows zero. See [ollama.com/pricing](https://ollama.com/pricing) for plan details.
@@ -93,13 +94,13 @@ Accepted disabling values are `0`, `false`, `no`, `off`, or an empty string. Whe
 
 ### 4. Fetch models
 
-On first launch the plugin will use a small set of fallback models. Run:
+On first launch the plugin registers a small hardcoded fallback list, then refreshes model metadata automatically with the same progress widget used by the manual command. If an existing cache is merely stale, that cached model list remains active while refresh runs. You can also run:
 
 ```
 /ollama-cloud-refresh
 ```
 
-This fetches the full model list from the Ollama Cloud API and caches it locally.
+This fetches the full model list from the Ollama Cloud API and overwrites the local cache.
 
 ### 5. Select a model
 
@@ -114,17 +115,42 @@ The plugin uses two Ollama Cloud API endpoints to build the model list:
 
 Only models with the `tools` capability are registered - these are the ones Pi can use for tool-calling.
 
-The raw `/api/show` responses are cached at `~/.pi/agent/cache/ollama-cloud-models.json`. This cache **never expires** - run `/ollama-cloud-refresh` to update it.
+The raw `/api/show` responses are cached at `~/.pi/agent/cache/ollama-cloud-models.json` with a top-level `timestamp` value. If that local cache is older than 30 days, the plugin keeps using it immediately and triggers the visible refresh flow on `session_start`. If the cache is missing or invalid, the plugin registers a small hardcoded model list until refresh succeeds. If no key is available or refresh fails, the current registered list remains active until `/ollama-cloud-refresh` succeeds.
 
 Model metadata is derived from the cached data:
 
 | Field | Source |
 |---|---|
 | `reasoning` | `capabilities` includes `"thinking"` |
+| `thinkingLevelMap` | `reasoning-models.json`; unknown thinking-capable models default to binary on/off with Pi `medium` as the single on level |
 | `input` | `["text", "image"]` if `capabilities` includes `"vision"`, else `["text"]` |
 | `contextWindow` | `model_info.*.context_length` (falls back to 128000) |
 | `maxTokens` | Fixed at 32768 |
 | `cost` | All zeros (Ollama Cloud uses subscription plans, not per-token billing - see [pricing](https://ollama.com/pricing)) |
+
+### Thinking level mapping
+
+Ollama currently exposes thinking support as a binary capability, not as a machine-readable list of effective thinking levels. Some endpoints accept values such as `low`, `medium`, `high`, or `max` even when the model treats them as the same binary "thinking on" mode, so this extension uses a curated catalog of effective levels instead of treating accepted request values as authoritative.
+
+Instead, `reasoning-models.json` curates the levels exposed to Pi, based on Ollama's [thinking capability docs](https://docs.ollama.com/capabilities/thinking) plus known model-specific behavior:
+
+| Model/family | Pi levels exposed | Notes |
+|---|---|---|
+| `deepseek-v4-pro` | `off`, `minimal`, `low`, `medium`, `high`, `xhigh` | Maps Pi `xhigh` to Ollama `max`. |
+| `gpt-oss*` | `low`, `medium`, `high` | Ollama docs list low/medium/high and no off mode. |
+| `qwen3*` | `off`, `medium` | Qwen 3.x is treated as binary on/off. |
+| `deepseek*` | `off`, `medium` | DeepSeek models are treated as binary on/off unless explicitly overridden. |
+| unknown thinking model | `off`, `medium` | Conservative binary default. |
+
+Pi talks to Ollama Cloud through its OpenAI-compatible `/v1/chat/completions` endpoint. For models where off is supported, Pi's `off` level maps to `reasoning_effort: "none"`; binary "on" maps to Pi `medium`.
+
+Refresh from inside Pi:
+
+```text
+/ollama-cloud-refresh
+```
+
+That command updates `~/.pi/agent/cache/ollama-cloud-models.json` with a new `timestamp` and re-registers the provider live, so no restart is required.
 
 ## Tools
 

--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,7 @@
  *   1. Get an API key from https://ollama.com
  *   2. Add to auth.json in the agent config dir (~/.pi/agent/auth.json, or set PI_CODING_AGENT_DIR):
  *      { "ollama-cloud": { "type": "api_key", "key": "your-key" } }
- *   3. Run /ollama-cloud-refresh to fetch models (uses cache or fallback on boot)
+ *   3. Run /ollama-cloud-refresh to fetch model metadata
  *   4. Use /model or ctrl+l to select an Ollama Cloud model
  *
  * Two endpoints are used to build the model list:
@@ -17,14 +17,22 @@
  * Raw /api/show responses are cached at <agentDir>/cache/ollama-cloud-models.json
  * so the provider assembly can be debugged and re-derived without re-fetching.
  *
- * Cache never expires -- run /ollama-cloud-refresh to update.
- * Cold cache falls back to a small set of hardcoded models.
+ * Local cache entries include timestamp. Stale local caches are used immediately while a visible startup
+ * refresh runs; missing/invalid caches use a small hardcoded model list until refresh completes.
  *
  * Only models with "tools" capability are registered.
  */
 
 import type { ExtensionAPI, ExtensionCommandContext, ProviderModelConfig } from "@mariozechner/pi-coding-agent";
-import { assembleModels, FALLBACK_MODELS, fetchModels, OLLAMA_BASE, readCache, writeCache } from "./models.ts";
+import {
+  assembleModels,
+  FALLBACK_MODELS,
+  fetchModels,
+  OLLAMA_BASE,
+  type RefreshProgress,
+  readCacheState,
+  writeCache,
+} from "./models.ts";
 import { registerWebFetchTool, registerWebSearchTool } from "./web-tools.ts";
 
 /**
@@ -48,30 +56,71 @@ function registerProvider(pi: ExtensionAPI, models: ProviderModelConfig[]) {
   });
 }
 
+function renderProgressBar(current: number, total: number, width = 15): string {
+  if (total <= 0) return `[${"░".repeat(width)}]`;
+  const ratio = Math.max(0, Math.min(1, current / total));
+  const filled = Math.round(ratio * width);
+  return `[${"█".repeat(filled)}${"░".repeat(width - filled)}]`;
+}
+
+function createRefreshProgressUi(ctx: Pick<ExtensionCommandContext, "ui">) {
+  const key = "ollama-cloud-refresh";
+  return {
+    update(progress: RefreshProgress) {
+      const current = progress.current ?? 0;
+      const total = progress.total ?? 0;
+      const percent = total > 0 ? Math.round((current / total) * 100) : 0;
+      const failed = progress.failed ? `, ${progress.failed} failed` : "";
+      const stage =
+        progress.stage === "list"
+          ? "Discovering models"
+          : progress.stage === "details"
+            ? "Fetching model details"
+            : "Done";
+      const summary = total > 0 ? `${current}/${total} (${percent}%${failed})` : progress.message;
+      const line = `☁ Ollama Cloud — ${stage} — ${summary} ${renderProgressBar(current, total)}`;
+
+      ctx.ui.setWorkingMessage(`Ollama Cloud refresh — ${progress.message}: ${summary}`);
+      ctx.ui.setWidget(key, [line], { placement: "belowEditor" });
+    },
+    clear() {
+      ctx.ui.setWidget(key, undefined);
+      ctx.ui.setStatus(key, undefined);
+      ctx.ui.setWorkingMessage();
+    },
+  };
+}
+
+async function runRefresh(pi: ExtensionAPI, ctx: Pick<ExtensionCommandContext, "ui">) {
+  const progressUi = createRefreshProgressUi(ctx);
+  try {
+    progressUi.update({ stage: "list", message: "Starting refresh..." });
+
+    const raw = await fetchModels(ctx, (progress) => progressUi.update(progress));
+    if (!raw) return false;
+
+    writeCache(raw);
+    const newModels = assembleModels(raw);
+
+    // NOTE: Some models may trigger errors like:
+    //   Error: 400 "developer is not one of ['system', 'assistant', 'user', 'tool', 'function']"
+    // If that comes up, consider setting `supportsDeveloperRole: false` in the compat field
+    // for the provider or specific models, e.g.:
+    //   compat: { supportsDeveloperRole: false }
+    registerProvider(pi, newModels);
+
+    ctx.ui.notify(`Registered ${newModels.length} Ollama Cloud models`, "info");
+    return true;
+  } finally {
+    progressUi.clear();
+  }
+}
+
 function registerRefreshCommand(pi: ExtensionAPI) {
   pi.registerCommand("ollama-cloud-refresh", {
     description: "Refresh Ollama Cloud models from the API",
     handler: async (_args: string, ctx: ExtensionCommandContext) => {
-      ctx.ui.setWorkingMessage("Refreshing Ollama Cloud models...");
-
-      const raw = await fetchModels(ctx);
-      if (!raw) {
-        ctx.ui.setWorkingMessage();
-        return;
-      }
-
-      writeCache(raw);
-      const newModels = assembleModels(raw);
-
-      // NOTE: Some models may trigger errors like:
-      //   Error: 400 "developer is not one of ['system', 'assistant', 'user', 'tool', 'function']"
-      // If that comes up, consider setting `supportsDeveloperRole: false` in the compat field
-      // for the provider or specific models, e.g.:
-      //   compat: { supportsDeveloperRole: false }
-      registerProvider(pi, newModels);
-
-      ctx.ui.notify(`Registered ${newModels.length} Ollama Cloud models`, "info");
-      ctx.ui.setWorkingMessage();
+      await runRefresh(pi, ctx);
     },
   });
 }
@@ -79,11 +128,21 @@ function registerRefreshCommand(pi: ExtensionAPI) {
 // --- Main ---
 
 export default async function (pi: ExtensionAPI) {
-  const cached = readCache();
-  const models = cached ? assembleModels(cached) : FALLBACK_MODELS;
+  const cacheState = readCacheState();
+  const needsStartupRefresh = cacheState.status !== "fresh";
+  const models = cacheState.status === "missing" ? FALLBACK_MODELS : assembleModels(cacheState.models);
 
   registerProvider(pi, models);
   registerRefreshCommand(pi);
+
+  if (needsStartupRefresh) {
+    let started = false;
+    pi.on("session_start", async (_event, ctx) => {
+      if (started) return;
+      started = true;
+      await runRefresh(pi, ctx);
+    });
+  }
 
   if (!WEB_TOOLS_DISABLED) {
     registerWebSearchTool(pi);

--- a/models.ts
+++ b/models.ts
@@ -1,20 +1,19 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { getModels, getProviders } from "@mariozechner/pi-ai";
 import {
   AuthStorage,
   type ExtensionCommandContext,
   getAgentDir,
   type ProviderModelConfig,
 } from "@mariozechner/pi-coding-agent";
+import { resolveThinkingLevelMap } from "./thinking.ts";
+import { fetchJsonWithTimeout, getContextLength, OLLAMA_BASE, runPool } from "./utils.ts";
 
 // --- Constants ---
 const CACHE_DIR = join(getAgentDir(), "cache");
 const CACHE_FILE = join(CACHE_DIR, "ollama-cloud-models.json");
+const CACHE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 10000;
-
-// --- API fetch ---
-export const OLLAMA_BASE = (process.env.OLLAMA_API_BASE || "https://ollama.com").replace(/\/+$/, "");
 
 // Initialize AuthStorage
 const authStorage = AuthStorage.create();
@@ -35,71 +34,27 @@ export interface OllamaShowResponse {
   modified_at: string;
 }
 
-/** On-disk cache: raw /api/show responses keyed by model ID */
-interface CachedData {
-  timestamp: number;
-  models: Record<string, OllamaShowResponse>;
+export type CachedOllamaModel = OllamaShowResponse;
+
+/** On-disk cache: raw /api/show responses keyed by model ID. */
+export interface CachedData {
+  /** Unix epoch milliseconds used to decide when the generated metadata is stale. */
+  timestamp?: number;
+  models: Record<string, CachedOllamaModel>;
+}
+
+export type RefreshProgressStage = "list" | "details" | "done";
+
+export interface RefreshProgress {
+  stage: RefreshProgressStage;
+  current?: number;
+  total?: number;
+  failed?: number;
+  message: string;
 }
 
 // --- Assembly: raw API data -> ProviderModelConfig[] ---
-function getContextLength(modelInfo: Record<string, unknown>): number {
-  for (const [key, value] of Object.entries(modelInfo)) {
-    if (key.endsWith(".context_length") && typeof value === "number") {
-      return value;
-    }
-  }
-  return 128000;
-}
-
-// --- Built-in model knowledge index ---
-// Build a lookup of model ID -> thinkingLevelMap from pi's built-in models.
-// This avoids hardcoding model-family mappings: when pi-mono updates its
-// model definitions (e.g. DeepSeek V4's thinking levels), the extension
-// picks up the changes automatically.
-const BUILTIN_THINKING_MAP: Record<string, ProviderModelConfig["thinkingLevelMap"]> = {};
-// Fallback: family stem -> [stem, thinkingLevelMap] pairs for models whose Ollama Cloud
-// ID doesn't match exactly.  The stem is derived by stripping provider prefixes and
-// non-alphanumeric characters (e.g. "gemma-4-31b-it" -> "gemma431bit").
-// When looking up an Ollama model by its details.family field, we search for a pi stem
-// that starts with the family stem (e.g. family "gemma4" -> pi "gemma431bit").
-// Entries are sorted longest-first so the most specific match wins.
-const BUILTIN_FAMILY_ENTRIES: [string, NonNullable<ProviderModelConfig["thinkingLevelMap"]>][] = [];
-for (const provider of getProviders()) {
-  for (const model of getModels(provider as any)) {
-    if (model.thinkingLevelMap) {
-      BUILTIN_THINKING_MAP[model.id] = model.thinkingLevelMap;
-      const stem = model.id
-        .replace(/^[a-z0-9-]+\//, "") // strip provider prefix (e.g. "zai/", "deepseek/")
-        .replace(/[^a-zA-Z0-9]/g, "") // strip non-alphanumeric
-        .toLowerCase();
-      BUILTIN_FAMILY_ENTRIES.push([stem, model.thinkingLevelMap]);
-    }
-  }
-}
-// Longest stems first so a more specific match (e.g. "gemma431bit") wins over a generic one (e.g. "gemma4").
-BUILTIN_FAMILY_ENTRIES.sort((a, b) => b[0].length - a[0].length);
-
-function resolveThinkingLevelMap(modelId: string, data: OllamaShowResponse): ProviderModelConfig["thinkingLevelMap"] {
-  // 1. Exact ID match (e.g. "deepseek-v4-pro")
-  const exact = BUILTIN_THINKING_MAP[modelId];
-  if (exact) return exact;
-
-  // 2. Family-based fallback: match Ollama's details.family against pi model stems
-  if (data.capabilities?.includes("thinking")) {
-    const familyStem = data.details?.family?.replace(/[^a-zA-Z0-9]/g, "").toLowerCase() ?? "";
-    if (familyStem) {
-      for (const [stem, tlm] of BUILTIN_FAMILY_ENTRIES) {
-        if (stem.startsWith(familyStem)) {
-          return tlm;
-        }
-      }
-    }
-  }
-
-  return undefined;
-}
-
-export function assembleModels(raw: Record<string, OllamaShowResponse>): ProviderModelConfig[] {
+export function assembleModels(raw: Record<string, CachedOllamaModel>): ProviderModelConfig[] {
   return Object.entries(raw)
     .filter(([, data]) => data.capabilities?.includes("tools"))
     .map(([id, data]) => ({
@@ -137,34 +92,173 @@ export const FALLBACK_MODELS: ProviderModelConfig[] = [
 ];
 
 // --- Cache I/O ---
-export function readCache(): Record<string, OllamaShowResponse> | null {
+export type CacheState =
+  | { status: "fresh"; models: Record<string, CachedOllamaModel> }
+  | { status: "stale"; models: Record<string, CachedOllamaModel> }
+  | { status: "missing" };
+
+function createCacheData(models: Record<string, CachedOllamaModel>, now = new Date()): CachedData {
+  return { timestamp: now.getTime(), models };
+}
+
+function readCacheData(path: string): CachedData | null {
   try {
-    if (!existsSync(CACHE_FILE)) return null;
-    const data: CachedData = JSON.parse(readFileSync(CACHE_FILE, "utf-8"));
+    const data: CachedData = JSON.parse(readFileSync(path, "utf-8"));
     if (!data.models || Object.keys(data.models).length === 0) return null;
-    return data.models;
+    return data;
   } catch {
     return null;
   }
 }
 
-export function writeCache(models: Record<string, OllamaShowResponse>): void {
+function isFreshGeneratedCache(data: CachedData): boolean {
+  if (typeof data.timestamp !== "number" || !Number.isFinite(data.timestamp)) return false;
+  return Date.now() - data.timestamp <= CACHE_MAX_AGE_MS;
+}
+
+export function readCacheState(): CacheState {
+  if (!existsSync(CACHE_FILE)) return { status: "missing" };
+
+  const data = readCacheData(CACHE_FILE);
+  if (!data) {
+    try {
+      rmSync(CACHE_FILE, { force: true });
+    } catch {
+      // Ignore cache delete errors.
+    }
+    return { status: "missing" };
+  }
+
+  return isFreshGeneratedCache(data)
+    ? { status: "fresh", models: data.models }
+    : { status: "stale", models: data.models };
+}
+
+export function readCache(): Record<string, CachedOllamaModel> | null {
+  const state = readCacheState();
+  return state.status === "missing" ? null : state.models;
+}
+
+export function writeCache(models: Record<string, CachedOllamaModel>): void {
   try {
     mkdirSync(CACHE_DIR, { recursive: true });
-    writeFileSync(CACHE_FILE, JSON.stringify({ timestamp: Date.now(), models } satisfies CachedData, null, 2));
+    writeFileSync(CACHE_FILE, JSON.stringify(createCacheData(models), null, 2));
   } catch {
     // Ignore cache write errors
   }
 }
 
 // --- Fetch Models ---
-export async function fetchModels(ctx: ExtensionCommandContext): Promise<Record<string, OllamaShowResponse> | null> {
-  const apiKey = (await authStorage.getApiKey("ollama-cloud")) ?? process.env.OLLAMA_API_KEY;
+async function fetchModelIds(apiKey: string, timeoutMs = FETCH_TIMEOUT_MS): Promise<string[]> {
+  const res = await fetchJsonWithTimeout<{ data: { id: string }[] }>(
+    `${OLLAMA_BASE}/v1/models`,
+    { headers: { Authorization: `Bearer ${apiKey}` } },
+    timeoutMs,
+  );
+  if (!res.ok || !res.data) throw new Error(`Failed to fetch model list: ${res.status || res.error}`);
+  return res.data.data.map((m) => m.id);
+}
+
+async function fetchModelDetails(apiKey: string, id: string, timeoutMs = FETCH_TIMEOUT_MS): Promise<CachedOllamaModel> {
+  const res = await fetchJsonWithTimeout<OllamaShowResponse>(
+    `${OLLAMA_BASE}/api/show`,
+    {
+      method: "POST",
+      headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ model: id }),
+    },
+    timeoutMs,
+  );
+  if (!res.ok || !res.data) throw new Error(`Failed to fetch /api/show for ${id}: ${res.status || res.error}`);
+  return res.data;
+}
+
+export async function refreshOllamaCloudModels(params: {
+  apiKey: string;
+  notify?: (message: string, level?: "info" | "error") => void;
+  onProgress?: (progress: RefreshProgress) => void;
+  workers?: number;
+}): Promise<Record<string, CachedOllamaModel>> {
+  const notify = params.notify ?? (() => undefined);
+  const onProgress = params.onProgress ?? (() => undefined);
+  onProgress({ stage: "list", message: "Fetching model list..." });
+  const modelIds = await fetchModelIds(params.apiKey);
+  notify(`Found ${modelIds.length} models, fetching details...`);
+  onProgress({ stage: "details", current: 0, total: modelIds.length, failed: 0, message: "Fetching model details" });
+
+  let detailsDone = 0;
+  let detailsFailed = 0;
+  const detailResults = await runPool(modelIds, params.workers ?? 8, async (id) => {
+    try {
+      return [id, await fetchModelDetails(params.apiKey, id)] as const;
+    } catch (error) {
+      detailsFailed++;
+      throw error;
+    } finally {
+      detailsDone++;
+      onProgress({
+        stage: "details",
+        current: detailsDone,
+        total: modelIds.length,
+        failed: detailsFailed,
+        message: "Fetching model details",
+      });
+    }
+  });
+  const models: Record<string, CachedOllamaModel> = {};
+  let failed = 0;
+  for (const result of detailResults) {
+    if (result.status === "fulfilled") {
+      const [id, data] = result.value;
+      models[id] = data;
+    } else {
+      failed++;
+    }
+  }
+  const succeeded = Object.keys(models).length;
+  if (succeeded === 0) throw new Error(`Failed to fetch model details${failed ? ` (${failed} failed)` : ""}`);
+  notify(`Fetched ${succeeded} model details${failed ? ` (${failed} failed)` : ""}`, "info");
+
+  onProgress({
+    stage: "done",
+    current: Object.keys(models).length,
+    total: Object.keys(models).length,
+    message: "Done",
+  });
+  return models;
+}
+
+async function getOllamaCloudApiKey(): Promise<string | undefined> {
+  return (await authStorage.getApiKey("ollama-cloud")) ?? process.env.OLLAMA_API_KEY;
+}
+
+export async function refreshModelsFromAuth(
+  params: {
+    notify?: (message: string, level?: "info" | "error") => void;
+    onProgress?: (progress: RefreshProgress) => void;
+  } = {},
+): Promise<Record<string, CachedOllamaModel> | null> {
+  const apiKey = await getOllamaCloudApiKey();
+  if (!apiKey) return null;
+
+  return refreshOllamaCloudModels({
+    apiKey,
+    notify: params.notify,
+    onProgress: params.onProgress,
+  });
+}
+
+export async function fetchModels(
+  ctx: Pick<ExtensionCommandContext, "ui">,
+  onProgress?: (progress: RefreshProgress) => void,
+): Promise<Record<string, CachedOllamaModel> | null> {
+  const apiKey = await getOllamaCloudApiKey();
 
   if (!apiKey) {
     ctx.ui.notify(
       "No Ollama Cloud API key found. \n" +
-        "Please ensure your API key is set in: \n" +
+        "Please ensure your API key is set in either: \n" +
+        "- OLLAMA_API_KEY environment variable,\n" +
         "- auth.json file (at ~/.pi/agent/auth.json) under 'ollama-cloud' key,\n" +
         "- or via the CLI --api-key flag.\n" +
         "Example auth.json entry: \n" +
@@ -174,61 +268,16 @@ export async function fetchModels(ctx: ExtensionCommandContext): Promise<Record<
     return null;
   }
 
-  // 1. Fetch model list from /v1/models
-  let modelIds: string[];
-  const listController = new AbortController();
-  const listTimeout = setTimeout(() => listController.abort(), FETCH_TIMEOUT_MS);
   try {
-    const res = await fetch(`${OLLAMA_BASE}/v1/models`, {
-      headers: { Authorization: `Bearer ${apiKey}` },
-      signal: listController.signal,
+    return await refreshOllamaCloudModels({
+      apiKey,
+      notify: (message, level) => ctx.ui.notify(message, level),
+      onProgress,
     });
-    if (!res.ok) {
-      ctx.ui.notify(`Failed to fetch model list: ${res.status}`, "error");
-      return null;
-    }
-    const data = (await res.json()) as { data: { id: string }[] };
-    modelIds = data.data.map((m) => m.id);
-    ctx.ui.notify(`Found ${modelIds.length} models, fetching details...`);
-  } catch {
-    ctx.ui.notify("Failed to fetch Ollama Cloud models", "error");
-    return null;
-  } finally {
-    clearTimeout(listTimeout);
-  }
-
-  // 2. Fetch /api/show for each model in parallel
-  const results: Record<string, OllamaShowResponse> = {};
-  await Promise.allSettled(
-    modelIds.map(async (id) => {
-      const showController = new AbortController();
-      const showTimeout = setTimeout(() => showController.abort(), FETCH_TIMEOUT_MS);
-      try {
-        const res = await fetch(`${OLLAMA_BASE}/api/show`, {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${apiKey}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ model: id }),
-          signal: showController.signal,
-        });
-        if (!res.ok) throw new Error(`status ${res.status}`);
-        const showData = (await res.json()) as OllamaShowResponse;
-        results[id] = showData;
-      } finally {
-        clearTimeout(showTimeout);
-      }
-    }),
-  );
-
-  const succeeded = Object.keys(results).length;
-  const failed = modelIds.length - succeeded;
-  if (succeeded === 0) {
-    ctx.ui.notify(`Failed to fetch model details${failed ? ` (${failed} failed)` : ""}`, "error");
+  } catch (error) {
+    ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
     return null;
   }
-  ctx.ui.notify(`Fetched ${succeeded} model details${failed ? ` (${failed} failed)` : ""}`, "info");
-
-  return results;
 }
+
+export { OLLAMA_BASE };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
   "files": [
     "index.ts",
     "models.ts",
+    "thinking.ts",
+    "utils.ts",
     "web-tools.ts",
+    "reasoning-models.json",
     "CHANGELOG.md",
     "README.md",
     "LICENSE"

--- a/reasoning-models.json
+++ b/reasoning-models.json
@@ -15,7 +15,7 @@
       "low": "low",
       "medium": "medium",
       "high": "high",
-      "xhigh": "max"
+      "xhigh": "xhigh"
     }
   },
   "patterns": [

--- a/reasoning-models.json
+++ b/reasoning-models.json
@@ -15,7 +15,7 @@
       "low": "low",
       "medium": "medium",
       "high": "high",
-      "xhigh": "xhigh"
+      "xhigh": "max"
     }
   },
   "patterns": [

--- a/reasoning-models.json
+++ b/reasoning-models.json
@@ -1,0 +1,56 @@
+{
+  "version": 1,
+  "default": {
+    "off": "none",
+    "minimal": null,
+    "low": null,
+    "medium": "medium",
+    "high": null,
+    "xhigh": null
+  },
+  "models": {
+    "deepseek-v4-pro": {
+      "off": "none",
+      "minimal": "low",
+      "low": "low",
+      "medium": "medium",
+      "high": "high",
+      "xhigh": "max"
+    }
+  },
+  "patterns": [
+    {
+      "match": "gpt-oss*",
+      "map": {
+        "off": null,
+        "minimal": null,
+        "low": "low",
+        "medium": "medium",
+        "high": "high",
+        "xhigh": null
+      }
+    },
+    {
+      "match": "qwen3*",
+      "map": {
+        "off": "none",
+        "minimal": null,
+        "low": null,
+        "medium": "medium",
+        "high": null,
+        "xhigh": null
+      }
+    },
+    {
+      "match": "deepseek*",
+      "map": {
+        "off": "none",
+        "minimal": null,
+        "low": null,
+        "medium": "medium",
+        "high": null,
+        "xhigh": null
+      }
+    }
+  ]
+}

--- a/thinking.ts
+++ b/thinking.ts
@@ -1,0 +1,89 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ProviderModelConfig } from "@mariozechner/pi-coding-agent";
+
+const PI_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
+const CATALOG_FILE = join(dirname(fileURLToPath(import.meta.url)), "reasoning-models.json");
+
+export type ThinkingLevelMap = NonNullable<ProviderModelConfig["thinkingLevelMap"]>;
+
+type CatalogPattern = {
+  match: string;
+  map: ThinkingLevelMap;
+};
+
+type ThinkingCatalog = {
+  version: number;
+  default: ThinkingLevelMap;
+  models?: Record<string, ThinkingLevelMap>;
+  patterns?: CatalogPattern[];
+};
+
+type ThinkingModelData = {
+  capabilities?: string[];
+  details?: { family?: string };
+};
+
+const BINARY_THINKING_MAP: ThinkingLevelMap = {
+  off: "none",
+  minimal: null,
+  low: null,
+  medium: "medium",
+  high: null,
+  xhigh: null,
+};
+
+function readThinkingCatalog(): ThinkingCatalog {
+  try {
+    const parsed = JSON.parse(readFileSync(CATALOG_FILE, "utf-8")) as Partial<ThinkingCatalog>;
+    return {
+      version: parsed.version ?? 1,
+      default: parsed.default ?? BINARY_THINKING_MAP,
+      models: parsed.models ?? {},
+      patterns: parsed.patterns ?? [],
+    };
+  } catch {
+    return { version: 1, default: BINARY_THINKING_MAP, models: {}, patterns: [] };
+  }
+}
+
+const THINKING_CATALOG = readThinkingCatalog();
+
+function normalize(value: string): string {
+  return value.toLowerCase();
+}
+
+function globMatches(pattern: string, value: string): boolean {
+  const escaped = pattern
+    .split("*")
+    .map((part) => part.replace(/[.+?^${}()|[\]\\]/g, "\\$&"))
+    .join(".*");
+  return new RegExp(`^${escaped}$`, "i").test(value);
+}
+
+export function resolveThinkingLevelMap(
+  modelId: string,
+  data: ThinkingModelData,
+): ProviderModelConfig["thinkingLevelMap"] {
+  if (!data.capabilities?.includes("thinking")) return undefined;
+
+  const normalizedModelId = normalize(modelId);
+  const exact = THINKING_CATALOG.models?.[normalizedModelId] ?? THINKING_CATALOG.models?.[modelId];
+  if (exact) return exact;
+
+  const family = data.details?.family ? normalize(data.details.family) : undefined;
+  for (const entry of THINKING_CATALOG.patterns ?? []) {
+    if (globMatches(entry.match, normalizedModelId) || (family && globMatches(entry.match, family))) {
+      return entry.map;
+    }
+  }
+
+  return THINKING_CATALOG.default;
+}
+
+export function formatThinkingLevelsForLog(model: ProviderModelConfig): string {
+  if (!model.reasoning) return "off";
+  const map = model.thinkingLevelMap ?? {};
+  return PI_THINKING_LEVELS.filter((level) => map[level] !== null).join(",");
+}

--- a/utils.ts
+++ b/utils.ts
@@ -1,0 +1,58 @@
+export const OLLAMA_BASE = (process.env.OLLAMA_API_BASE || "https://ollama.com").replace(/\/+$/, "");
+
+export async function fetchJsonWithTimeout<T>(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<{ ok: boolean; status: number; data: T | null; error?: string }> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { ...init, signal: controller.signal });
+    const text = await res.text();
+    let data: T | null = null;
+    try {
+      data = text ? (JSON.parse(text) as T) : null;
+    } catch {
+      // Keep data null and report text below.
+    }
+    const error =
+      data && typeof data === "object" && "error" in data ? String((data as { error: unknown }).error) : text;
+    return { ok: res.ok, status: res.status, data, error: res.ok ? undefined : error };
+  } catch (error) {
+    return { ok: false, status: 0, data: null, error: error instanceof Error ? error.message : String(error) };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function runPool<T, R>(
+  items: T[],
+  workers: number,
+  fn: (item: T) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> {
+  const results: PromiseSettledResult<R>[] = new Array(items.length);
+  let next = 0;
+  await Promise.all(
+    Array.from({ length: Math.max(1, workers) }, async () => {
+      while (next < items.length) {
+        const index = next++;
+        try {
+          results[index] = { status: "fulfilled", value: await fn(items[index]) };
+        } catch (reason) {
+          results[index] = { status: "rejected", reason };
+        }
+      }
+    }),
+  );
+  return results;
+}
+
+export function getContextLength(modelInfo: Record<string, unknown>): number {
+  for (const [key, value] of Object.entries(modelInfo)) {
+    if (key.endsWith(".context_length") && typeof value === "number") {
+      return value;
+    }
+  }
+  return 128000;
+}


### PR DESCRIPTION
Fixes #6

## Summary
- fix `/api/chat` requests were not disabling thinking correctly (before: setting think to `off` in pi would still result in thinking being enabled)
- add curated reasoning-models.json for effective Ollama Cloud thinking levels
- refresh stale/missing model metadata on session startup with the same visible progress UI as /ollama-cloud-refresh
- keep stale caches active while refreshing and use fallback models only for missing/invalid caches
- add progress bar
- split model refresh helpers into focused utility modules

## Dets
- I've run a smoke test against ollama cloud with all thinking levels, across all models
- It seems that it's opaque on the api level, and the server will translate each to whatever given model expects 
- I.e. qwen3.* series only supports `think` and `nothink`, without gradation, but the api still accepts i.e. `max` as valid param. 
- The api server will accept any level, even if model doesn't support it
- This PR cleans all that up - for known models there's now a catalog that maps the think levels to pi's
- Upon initial install it was a bit WTF that the plugin didn't work, so I've added auto-refresh on first install, or if the cache is more than 30 days old. Just nice UX.
- Added a progress bar as a widget, to see how it's progressing. Occasionally ollama cloud can be slow. 
