### PR TITLE
fix: disable developer role for Ollama Cloud provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- Fix system prompt (AGENTS.md content) not being read by GLM models. The provider was sending the system prompt with `role: "developer"` for models with `reasoning: true`, but Ollama Cloud's API doesn't handle that role for GLM models. Forced `supportsDeveloperRole: false` so the system prompt always uses `role: "system"`, which works across all models.
+
 ## [0.3.1] - 2026-05-05
 
 - Fix `OLLAMA_API_KEY` env var not being respected by `fetchModels` and web tools. pi-ai does not know about the `ollama-cloud` provider ID, so `AuthStorage.getApiKey()` alone misses the env var. Added explicit `process.env.OLLAMA_API_KEY` fallback.

--- a/models.ts
+++ b/models.ts
@@ -111,6 +111,7 @@ export function assembleModels(raw: Record<string, OllamaShowResponse>): Provide
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       contextWindow: getContextLength(data.model_info ?? {}),
       maxTokens: 32768,
+      compat: { supportsDeveloperRole: false },
     }));
 }
 
@@ -124,6 +125,7 @@ export const FALLBACK_MODELS: ProviderModelConfig[] = [
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 202752,
     maxTokens: 32768,
+    compat: { supportsDeveloperRole: false },
   },
   {
     id: "gemma4:31b",
@@ -133,6 +135,7 @@ export const FALLBACK_MODELS: ProviderModelConfig[] = [
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 262144,
     maxTokens: 32768,
+    compat: { supportsDeveloperRole: false },
   },
 ];
 


### PR DESCRIPTION
Forces the system prompt to use `role: "system"` instead of `role: "developer"` for all Ollama Cloud models. Some models (e.g. GLM-5.1) ignore the `developer` role, which caused AGENTS.md content to be invisible to them. DeepSeek V4 Flash happens to handle both roles, so the bug went unnoticed for that model.

## Changes

- Adds `compat: { supportsDeveloperRole: false }` to all assembled models in `assembleModels()`
- Adds the same compat setting to both fallback models (`glm-5.1`, `gemma4:31b`)

## Testing

- Create a simple `AGENTS.md` with `The user's name is John`
- `pi --no-extensions -e . --thinking off --model ollama-cloud/glm-5.1 -p 'Whats my name?'` should now correctly read the name from AGENTS.md
- `pi --no-extensions -e . --thinking off --model ollama-cloud/deepseek-v4-flash -p 'Whats my name?'` should continue to work