### PR TITLE
Add renderCall to ollama_web_search and ollama_web_fetch to see what is being searched/fetched

### DIFF
--- a/web-tools.ts
+++ b/web-tools.ts
@@ -162,6 +162,12 @@ export function registerWebSearchTool(pi: ExtensionAPI) {
         };
       }
     },
+    renderCall(args, theme, _context) {
+      const display = args.query
+        ? `ollama_web_search("${args.query}")`
+        : "ollama_web_search";
+      return new Text(theme.fg("toolTitle", display), 0, 0);
+    },
     renderResult: createRenderResult(),
   });
 }
@@ -221,6 +227,12 @@ export function registerWebFetchTool(pi: ExtensionAPI) {
           isError: true,
         };
       }
+    },
+    renderCall(args, theme, _context) {
+      const display = args.url
+        ? `ollama_web_fetch("${args.url}")`
+        : "ollama_web_fetch";
+      return new Text(theme.fg("toolTitle", display), 0, 0);
     },
     renderResult: createRenderResult(),
   });


### PR DESCRIPTION
Add renderCall to ollama_web_search and ollama_web_fetch to see what is being searched/fetched
 
## Problem

Currently when you search or fetch a url with `ollama_web_search` or `ollama_web_fetch`, the TUI text box shows no indication of what keywords the model is using for searching or what url is being actually fetched. At least I would like to know what exactly the model is searching and fetching from the internet.


## Proposed solution

 This PR displays in the TUI text box header the query/URL in the tool call header instead of just the bare tool name.
 E.g. ollama_web_fetch("https://...") instead of ollama_web_fetch.
 
**Before**:
 
 ```markdown
 ollama_web_search
 1. Current Local Time in Paris, Paris, France
    URL: https://www.timeanddate.com/worldclock/france/paris
    Current Local Time in Paris, Paris, France

 Saturday, 2 May 2026

 ## Weather

 22 °C
...
 ```


**Now**:

```markdown
ollama_web_search("current time in Paris France")
 1. Current Local Time in Paris, Paris, France
    URL: https://www.timeanddate.com/worldclock/france/paris
    Current Local Time in Paris, Paris, France

 Saturday, 2 May 2026

 ## Weather

 22 °C
...
```

## Attribution

PR made in collaboration with  **deepseek-v4-flash** served by Ollama using **pi-ollama-cloud** extension in Pi ;)

