### PR TITLE
feat: config file support + runtime web tools toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Both tools use the same Ollama Cloud API key configured for the provider. No loc
 | Command | Description |
 |---|---|
 | `/ollama-cloud-refresh` | Fetch models from the Ollama Cloud API, update cache, and re-register the provider |
+| `/ollama-webtools [on\|off\|enable\|disable]` | Enable or disable the `ollama_web_search` and `ollama_web_fetch` tools. Toggles if no argument given. |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -82,15 +82,30 @@ Or add it to `~/.pi/agent/auth.json`:
 }
 ```
 
-### 3. Disable web tools (optional)
+### 3. Configure the extension (optional)
 
-If you want to use a different web search or fetch tool (e.g. Brave) by default, and need to avoid conflicts with the built-in Ollama Cloud tools, set the `PI_OLLAMA_WEB_TOOLS` environment variable to any falsy value:
+Extension settings can be set via JSON config files. Project-local settings override global/user-level settings.
 
-```bash
-export PI_OLLAMA_WEB_TOOLS=0
+| Location | Scope |
+|---|---|
+| `~/.pi/agent/ollama-cloud.json` | Global / user-level (all projects) |
+| `.pi/ollama-cloud.json` | Project-local (takes precedence) |
+
+**Available settings:**
+
+| Setting | Type | Default | Description |
+|---|---|---|---|
+| `webTools` | boolean | `true` | Set to `false` to prevent `ollama_web_search` and `ollama_web_fetch` from being registered |
+
+Example `ollama-cloud.json`:
+
+```json
+{
+  "webTools": false
+}
 ```
 
-Accepted disabling values are `0`, `false`, `no`, `off`, or an empty string. When disabled, `ollama_web_search` and `ollama_web_fetch` are not registered. The model provider and `/ollama-cloud-refresh` command remain active regardless.
+The `PI_OLLAMA_WEB_TOOLS` environment variable still works as an override above config files. Set it to `0`, `false`, `no`, or `off` to disable web tools regardless of config file settings.
 
 ### 4. Fetch models
 

--- a/config.ts
+++ b/config.ts
@@ -1,0 +1,99 @@
+/**
+ * Configuration loader for pi-ollama-cloud.
+ *
+ * Reads settings from JSON config files with project-over-global precedence:
+ *   - ~/.pi/agent/ollama-cloud.json (global / user-level)
+ *   - .pi/ollama-cloud.json        (project-local, takes precedence)
+ *
+ * Environment variables serve as overrides above both config files:
+ *   - PI_OLLAMA_WEB_TOOLS=0  disables web tool registration
+ *
+ * Example ollama-cloud.json:
+ * ```json
+ * {
+ *   "webTools": false
+ * }
+ * ```
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { getAgentDir } from "@mariozechner/pi-coding-agent";
+
+// --- Types ---
+
+export interface OllamaCloudConfig {
+  /** When false, ollama_web_search and ollama_web_fetch tools are not registered. Default: true. */
+  webTools?: boolean;
+}
+
+// --- Defaults ---
+
+const DEFAULT_CONFIG: OllamaCloudConfig = {
+  webTools: true,
+};
+
+// --- Loader ---
+
+/**
+ * Load configuration from JSON files.
+ * Project-local config overrides global config.
+ * Environment variables override both.
+ */
+export function loadConfig(cwd: string): OllamaCloudConfig {
+  const globalPath = join(getAgentDir(), "ollama-cloud.json");
+  const projectPath = join(cwd, ".pi", "ollama-cloud.json");
+
+  let globalConfig: OllamaCloudConfig = {};
+  let projectConfig: OllamaCloudConfig = {};
+
+  // Load global config
+  if (existsSync(globalPath)) {
+    try {
+      const content = readFileSync(globalPath, "utf-8");
+      globalConfig = JSON.parse(content);
+    } catch (err) {
+      console.error(`[pi-ollama-cloud] Failed to load config from ${globalPath}: ${err}`);
+    }
+  }
+
+  // Load project config
+  if (existsSync(projectPath)) {
+    try {
+      const content = readFileSync(projectPath, "utf-8");
+      projectConfig = JSON.parse(content);
+    } catch (err) {
+      console.error(`[pi-ollama-cloud] Failed to load config from ${projectPath}: ${err}`);
+    }
+  }
+
+  // Merge with defaults: defaults < global < project
+  const merged: OllamaCloudConfig = {
+    ...DEFAULT_CONFIG,
+    ...globalConfig,
+    ...projectConfig,
+  };
+
+  // Environment variable overrides (only webTools for now)
+  const envOverride = resolveWebToolsEnv();
+  if (envOverride !== undefined) {
+    merged.webTools = envOverride;
+  }
+
+  return merged;
+}
+
+/**
+ * Resolve the PI_OLLAMA_WEB_TOOLS environment variable override.
+ * Returns undefined when not set (no override),
+ * true/false when explicitly set.
+ */
+function resolveWebToolsEnv(): boolean | undefined {
+  const raw = process.env.PI_OLLAMA_WEB_TOOLS;
+  if (raw === undefined) return undefined;
+
+  const lowered = raw.toLowerCase();
+  if (["0", "false", "no", "off", ""].includes(lowered)) return false;
+  // Treat any other non-empty value as "enabled"
+  return true;
+}

--- a/index.ts
+++ b/index.ts
@@ -130,17 +130,93 @@ export default async function (pi: ExtensionAPI) {
     });
   }
 
-  // Register web tools based on config (loaded on session_start so
-  // project-local .pi/ollama-cloud.json can take effect).
-  // Guard prevents double-registration on reload.
-  let webToolsRegistered = false;
-  pi.on("session_start", async (_event, ctx) => {
-    if (webToolsRegistered) return;
-    const config = loadConfig(ctx.cwd);
-    if (config.webTools !== false) {
-      webToolsRegistered = true;
+  // --- Web Tools Management ---
+
+  /**
+   * Ensure web tools are registered (idempotent).
+   * Returns true if any tools were newly registered.
+   */
+  function ensureWebToolsRegistered(): boolean {
+    const allTools = pi.getAllTools();
+    let registered = false;
+    if (!allTools.some((t) => t.name === "ollama_web_search")) {
       registerWebSearchTool(pi);
-      registerWebFetchTool(pi);
+      registered = true;
     }
+    if (!allTools.some((t) => t.name === "ollama_web_fetch")) {
+      registerWebFetchTool(pi);
+      registered = true;
+    }
+    return registered;
+  }
+
+  /**
+   * Add or remove web tools from the active tools set.
+   */
+  function setWebToolsActive(active: boolean) {
+    const currentActive = pi.getActiveTools();
+    const webToolNames = ["ollama_web_search", "ollama_web_fetch"];
+
+    if (active) {
+      const missing = webToolNames.filter((n) => !currentActive.includes(n));
+      if (missing.length > 0) {
+        pi.setActiveTools([...currentActive, ...missing]);
+      }
+    } else {
+      const filtered = currentActive.filter((t) => !webToolNames.includes(t));
+      if (filtered.length < currentActive.length) {
+        pi.setActiveTools(filtered);
+      }
+    }
+  }
+
+  // Module-level tracking across session restarts within the same extension
+  // instance. Resets on /reload or extension teardown, which is the desired
+  // behavior (session_start re-reads config for the new session).
+  let webToolsConfigured = false;
+  let webToolsEnabled = false;
+
+  pi.on("session_start", async (_event, ctx) => {
+    if (!webToolsConfigured) {
+      webToolsConfigured = true;
+      const config = loadConfig(ctx.cwd);
+      if (config.webTools !== false) {
+        webToolsEnabled = true;
+        ensureWebToolsRegistered();
+      }
+    }
+    // On every session start (including resume/fork/new), re-apply the
+    // runtime state. Tools may have been unregistered during teardown.
+    if (webToolsEnabled) {
+      ensureWebToolsRegistered();
+      setWebToolsActive(true);
+    }
+  });
+
+  pi.registerCommand("ollama-webtools", {
+    description:
+      "Enable or disable Ollama Cloud web tools (ollama_web_search, ollama_web_fetch). " +
+      "Accepts optional argument: on/off/enable/disable. Without argument, toggles.",
+    handler: async (args, ctx) => {
+      const arg = args.trim().toLowerCase();
+
+      if (arg === "on" || arg === "enable") {
+        webToolsEnabled = true;
+      } else if (arg === "off" || arg === "disable") {
+        webToolsEnabled = false;
+      } else {
+        // Toggle current state
+        webToolsEnabled = !webToolsEnabled;
+      }
+
+      if (webToolsEnabled) {
+        ensureWebToolsRegistered();
+        setWebToolsActive(true);
+      } else {
+        setWebToolsActive(false);
+      }
+
+      ctx.ui.notify(`Ollama Web Tools: ${webToolsEnabled ? "enabled" : "disabled"}`, "info");
+    },
   });
 }

--- a/index.ts
+++ b/index.ts
@@ -24,6 +24,7 @@
  */
 
 import type { ExtensionAPI, ExtensionCommandContext, ProviderModelConfig } from "@mariozechner/pi-coding-agent";
+import { loadConfig } from "./config.ts";
 import {
   assembleModels,
   FALLBACK_MODELS,
@@ -34,16 +35,6 @@ import {
   writeCache,
 } from "./models.ts";
 import { registerWebFetchTool, registerWebSearchTool } from "./web-tools.ts";
-
-/**
- * Opt-out flag for the ollama_web_search and ollama_web_fetch tools.
- * When the value is one of "0", "false", "no", "off", or the empty string,
- * both web tool registrations are skipped. The model provider and
- * /ollama-cloud-refresh command remain active regardless.
- */
-const PI_OWT_RAW = process.env.PI_OLLAMA_WEB_TOOLS;
-const WEB_TOOLS_DISABLED =
-  PI_OWT_RAW !== undefined && ["0", "false", "no", "off", ""].includes(PI_OWT_RAW.toLowerCase());
 
 // --- Registrations ---
 
@@ -139,8 +130,17 @@ export default async function (pi: ExtensionAPI) {
     });
   }
 
-  if (!WEB_TOOLS_DISABLED) {
-    registerWebSearchTool(pi);
-    registerWebFetchTool(pi);
-  }
+  // Register web tools based on config (loaded on session_start so
+  // project-local .pi/ollama-cloud.json can take effect).
+  // Guard prevents double-registration on reload.
+  let webToolsRegistered = false;
+  pi.on("session_start", async (_event, ctx) => {
+    if (webToolsRegistered) return;
+    const config = loadConfig(ctx.cwd);
+    if (config.webTools !== false) {
+      webToolsRegistered = true;
+      registerWebSearchTool(pi);
+      registerWebFetchTool(pi);
+    }
+  });
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   ],
   "files": [
     "index.ts",
+    "config.ts",
     "models.ts",
     "thinking-levels.ts",
     "utils.ts",


### PR DESCRIPTION
   ## Summary

   Two improvements for controlling the `ollama_web_search` and `ollama_web_fetch` tools:

   1. **JSON config files** — project-local and global settings, following pi's `preset.ts` pattern
   2. **`/ollama-webtools` slash command** — enable/disable/toggle web tools at runtime without restarting

   ---

   ### 1. JSON config file support

   Previously the only way to disable web tools was the `PI_OLLAMA_WEB_TOOLS` env var. Now you can use JSON config files:

   | Location | Scope |
   |---|---|
   | `~/.pi/agent/ollama-cloud.json` | Global / user-level |
   | `.pi/ollama-cloud.json` | Project-local (takes precedence) |

   ```json
   {
     "webTools": false
   }
 ```

 The new config.ts module merges with precedence: env var → project config → global config → defaults. The PI_OLLAMA_WEB_TOOLS env var still works as an override above
 everything.

 ### 2. Runtime web tools toggle

 The new /ollama-webtools command toggles web tools live — no restart, no config editing:

 ```
   /ollama-webtools               # toggle current state
   /ollama-webtools on|enable     # enable
   /ollama-webtools off|disable   # disable
 ```

 Uses idempotent ensureWebToolsRegistered() (won't double-register) and setWebToolsActive() helpers. Module-level state survives session restarts within the same extension
 instance; resets on /reload or extension teardown.