### PR TITLE
fix: update FALLBACK_MODELS vision capabilities and reasoning flags

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -25,7 +25,9 @@
 
 import type { ExtensionAPI, ExtensionCommandContext, ProviderModelConfig } from "@mariozechner/pi-coding-agent";
 import {
+  addFallbackModels,
   assembleModels,
+  FALLBACK_ALIASES,
   FALLBACK_MODELS,
   fetchModels,
   OLLAMA_BASE,
@@ -100,7 +102,7 @@ async function runRefresh(pi: ExtensionAPI, ctx: Pick<ExtensionCommandContext, "
     if (!raw) return false;
 
     writeCache(raw);
-    const newModels = assembleModels(raw);
+    const newModels = addFallbackModels(assembleModels(raw));
 
     registerProvider(pi, newModels);
 
@@ -125,10 +127,33 @@ function registerRefreshCommand(pi: ExtensionAPI) {
 export default async function (pi: ExtensionAPI) {
   const cacheState = readCacheState();
   const needsStartupRefresh = cacheState.status !== "fresh";
-  const models = cacheState.status === "missing" ? FALLBACK_MODELS : assembleModels(cacheState.models);
+  const models = addFallbackModels(
+    cacheState.status === "missing" ? FALLBACK_MODELS : assembleModels(cacheState.models)
+  );
 
   registerProvider(pi, models);
   registerRefreshCommand(pi);
+
+  // Transparently remap alias model IDs to real backend model IDs before
+  // forwarding the request to the Ollama Cloud API.
+  // This prevents 404 errors when a task is routed to e.g.
+  // `ollama-cloud/qwen3.6-plus` which doesn't actually exist on
+  // ollama.com; it silently falls back to `qwen3.5:397b` instead.
+  pi.on("before_provider_request", async (event, ctx) => {
+    const payload = event.payload as Record<string, unknown> | undefined;
+    if (!payload || typeof payload !== "object" || !payload.model) return;
+
+    // Defensive: only interfere for ollama-cloud provider.
+    const activeModel = ctx.model as { provider?: string } | undefined;
+    if (activeModel?.provider !== "ollama-cloud") return;
+
+    const match = FALLBACK_ALIASES[payload.model as string];
+    if (!match) return; // not an alias, pass through unchanged
+    const realModelId = Array.isArray(match) ? match[0] : match;
+
+    payload.model = realModelId;
+    return payload;
+  });
 
   if (needsStartupRefresh) {
     let started = false;

--- a/models.ts
+++ b/models.ts
@@ -77,7 +77,7 @@ export const FALLBACK_MODELS: ProviderModelConfig[] = [
   {
     id: "glm-5.1",
     name: "GLM 5.1",
-    reasoning: false,
+    reasoning: true,
     input: ["text"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 202752,
@@ -87,8 +87,8 @@ export const FALLBACK_MODELS: ProviderModelConfig[] = [
   {
     id: "gemma4:31b",
     name: "Gemma 4 31B",
-    reasoning: false,
-    input: ["text"],
+    reasoning: true,
+    input: ["text", "image"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 262144,
     maxTokens: 32768,
@@ -108,9 +108,9 @@ export const FALLBACK_MODELS: ProviderModelConfig[] = [
     id: "qwen3.5",
     name: "Qwen 3.5",
     reasoning: true,
-    input: ["text"],
+    input: ["text", "image"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: 131072,
+    contextWindow: 262144,
     maxTokens: 32768,
     compat: { supportsDeveloperRole: false },
   },
@@ -118,9 +118,9 @@ export const FALLBACK_MODELS: ProviderModelConfig[] = [
     id: "kimi-k2.6",
     name: "Kimi K2.6",
     reasoning: true,
-    input: ["text"],
+    input: ["text", "image"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: 131072,
+    contextWindow: 262144,
     maxTokens: 32768,
     compat: { supportsDeveloperRole: false },
   },
@@ -276,6 +276,44 @@ async function refreshModelsFromAuth(
     notify: params.notify,
     onProgress: params.onProgress,
   });
+}
+
+// --- Model Fallback Aliases ---
+/**
+ * Maps model IDs that don't exist on Ollama Cloud to their closest available equivalents.
+ * Aliases are transparent: the model appears in the selector with the alias name, but API
+ * requests are remapped to the real backend model via the `before_provider_request` hook.
+ */
+export const FALLBACK_ALIASES: Record<string, string | string[]> = {
+  "qwen3.6-plus": ["qwen3.5:397b", "qwen3.5"],
+};
+
+/**
+ * Expands a model list with fallback aliases. Each alias copies all properties
+ * from its target model. If the target model isn't in the assembled list, the
+ * alias is silently skipped (e.g. during cold cache before refresh completes).
+ */
+export function addFallbackModels(models: ProviderModelConfig[]): ProviderModelConfig[] {
+  const existingIds = new Set(models.map((m) => m.id));
+  const aliases: ProviderModelConfig[] = [];
+  for (const [aliasId, targetId] of Object.entries(FALLBACK_ALIASES)) {
+    if (existingIds.has(aliasId)) continue;
+    const targetIds = Array.isArray(FALLBACK_ALIASES[aliasId])
+      ? FALLBACK_ALIASES[aliasId]
+      : [FALLBACK_ALIASES[aliasId]];
+    let target = undefined;
+    for (const targetId of (targetIds as string[])) {
+      target = models.find((m) => m.id === targetId);
+      if (target) break;
+    }
+    if (!target) continue;
+    aliases.push({
+      ...target,
+      id: aliasId,
+      name: aliasId,
+    });
+  }
+  return aliases.length > 0 ? [...models, ...aliases] : models;
 }
 
 export async function fetchModels(


### PR DESCRIPTION
## Problem

The `FALLBACK_MODELS` array (used during cold/missing cache) had outdated capability metadata that did not match actual Ollama Cloud `/api/show` responses. This caused models to appear as **text-only** in the model selector even though they support **image input** on Ollama Cloud.

### Affected models

| Model | Before | After | Issue |
|-------|--------|-------|-------|
| `gemma4:31b` | `input: ["text"]`, `reasoning: false` | `input: ["text", "image"]`, `reasoning: true` | Ollama reports `thinking` + `vision` |
| `qwen3.5` | `input: ["text"]`, ctx 131072 | `input: ["text", "image"]`, ctx 262144 | Ollama reports `vision`, actual ctx is 262K |
| `kimi-k2.6` | `input: ["text"]`, ctx 131072 | `input: ["text", "image"]`, ctx 262144 | Ollama reports `vision`, actual ctx is 262K |
| `glm-5.1` | `reasoning: false` | `reasoning: true` | Ollama reports `thinking` |

### Impact

When the cache is missing or stale (e.g. first startup before `/ollama-cloud-refresh` completes), users selecting these models would:
1. Not be able to attach images even though the model supports it
2. Get incorrect context window limits
3. Miss reasoning/thinking capabilities

### Note on DeepSeek models

`deepseek-v4-pro` correctly remains `input: ["text"]` — Ollama Cloud does **not** report `vision` for DeepSeek models. This is expected.

## Changes

1. **`models.ts`**: Updated 4 FALLBACK_MODELS entries with correct `input`, `reasoning`, and `contextWindow` values
2. **`models.ts`**: Added `FALLBACK_ALIASES` for `qwen3.6-plus` → `qwen3.5:397b` mapping
3. **`models.ts`**: Added `addFallbackModels()` function to expand model lists with aliases
4. **`index.ts`**: Integrated `addFallbackModels()` into startup and refresh flows
5. **`index.ts`**: Added `before_provider_request` hook for transparent alias ID remapping

## Verification

Verified against live Ollama Cloud `/api/show` cache (2026-05-27):

```
qwen3.5:397b:  [completion, thinking, tools, vision]  ctx=262144
kimi-k2.6:     [vision, thinking, completion, tools]   ctx=262144  
gemma4:31b:    [completion, thinking, tools, vision]   ctx=262144
glm-5.1:       [thinking, completion, tools]           ctx=202752
deepseek-v4-pro: [completion, tools, thinking]         ctx=1000000 (no vision — correct)
```