### PR TITLE
fix: await AuthStorage.getApiKey before OLLAMA_API_KEY fallback

### DIFF
--- a/web-tools.ts
+++ b/web-tools.ts
@@ -34,7 +34,7 @@ interface FetchResponse {
 const authStorage = AuthStorage.create();
 
 async function getCloudApiKey(): Promise<string | undefined> {
-  return authStorage.getApiKey("ollama-cloud") ?? process.env.OLLAMA_API_KEY;
+  return (await authStorage.getApiKey("ollama-cloud")) ?? process.env.OLLAMA_API_KEY;
 }
 
 function noApiKeyError() {


### PR DESCRIPTION
## Summary

`getCloudApiKey()` in `web-tools.ts` returned the `Promise` from `authStorage.getApiKey("ollama-cloud")` directly, so the `?? process.env.OLLAMA_API_KEY` fallback was never evaluated. This caused `ollama_web_search` and `ollama_web_fetch` to report "No Ollama Cloud API key configured" even when `OLLAMA_API_KEY` was set in the environment.

## Fix

Await the async lookup before applying the nullish coalescing fallback.

```ts
return (await authStorage.getApiKey("ollama-cloud")) ?? process.env.OLLAMA_API_KEY;
```

Closes #24
