### PR TITLE
fix: always target ollama.com and warn if OLLAMA_API_BASE is set

### DIFF
--- a/models.ts
+++ b/models.ts
@@ -10,7 +10,21 @@ const CACHE_FILE = join(CACHE_DIR, "ollama-cloud-models.json");
 const CACHE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 const FETCH_TIMEOUT_MS = 10000;
 
-export const OLLAMA_BASE = (process.env.OLLAMA_API_BASE || "https://ollama.com").replace(/\/+$/, "");
+// The cloud extension always targets ollama.com; local Ollama daemons (typically
+// pointed at via OLLAMA_API_BASE for the local CLI) are a different product and
+// must not silently redirect cloud requests. Warn once at module load if the
+// env var looks like a non-cloud target so the misconfiguration is visible.
+const CLOUD_BASE_URL = "https://ollama.com";
+const envBase = typeof process !== "undefined" ? process.env?.OLLAMA_API_BASE : undefined;
+if (envBase && !/^https:\/\/ollama\.com\b/i.test(envBase)) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[pi-ollama-cloud] Ignoring OLLAMA_API_BASE=${envBase}; ` +
+      `this extension always targets ${CLOUD_BASE_URL}. ` +
+      `Unset OLLAMA_API_BASE (or set it to the cloud URL) to silence this warning.`,
+  );
+}
+export const OLLAMA_BASE = CLOUD_BASE_URL.replace(/\/+$/, "");
 
 // --- Raw API types ---
 /** Response from POST /api/show */


### PR DESCRIPTION
# PR: Stop honoring `OLLAMA_API_BASE` in the cloud extension

Fixes the silent fallback described in #32.
When the local Ollama CLI is in use (very common), `OLLAMA_API_BASE`
typically points at `http://127.0.0.1:11434`. The cloud extension was
reading that variable too, so `/ollama-cloud-refresh` quietly queried
the local daemon and registered only the models that happened to be
pulled locally, with no warning or error.

This PR makes the cloud extension always target `https://ollama.com`
and adds a one-time startup warning if `OLLAMA_API_BASE` is set to
anything else, so the misconfiguration becomes visible instead of
silent.

## Changes

### `models.ts`

```ts
// before
export const OLLAMA_BASE = (process.env.OLLAMA_API_BASE || "https://ollama.com");
```

```ts
// after
export const OLLAMA_BASE = "https://ollama.com";

if (typeof process !== "undefined" && process.env?.OLLAMA_API_BASE) {
  const target = process.env.OLLAMA_API_BASE;
  if (!/^https:\/\/ollama\.com/i.test(target)) {
    // eslint-disable-next-line no-console
    console.warn(
      `[pi-ollama-cloud] Ignoring OLLAMA_API_BASE=${target}; ` +
        `this extension always targets https://ollama.com. ` +
        `Unset OLLAMA_API_BASE or set it to the cloud URL to silence this warning.`,
    );
  }
}
```

The `OLLAMA_BASE` export keeps its name so other modules in the
package don't need to be touched. The warning fires once at module
load, which is enough to make the misconfiguration discoverable.

### Notes on the suggested fix

I considered reading `OLLAMA_API_BASE` only when an explicit
`OLLAMA_CLOUD_BASE` is unset, so users could opt back into a local
target. I left that out of this PR because:

- The cloud extension is the only thing in this package, and the
  README is unambiguous about targeting the cloud URL.
- Anyone who actually wants to point this at a local daemon can
  fork; the common case is the opposite (unintended fallback).
- Adding two env vars without a concrete use case just creates a
  new footgun.

Happy to add the opt-in escape hatch as a follow-up if maintainers
think it's worth carrying.

## Testing

Manual verification against the patched extension:

- With `OLLAMA_API_BASE` unset → all 34 models register in ~0.4s, no
  retries, no warnings.
- With `OLLAMA_API_BASE=http://127.0.0.1:11434` → all 34 models
  still register from `ollama.com`, and the warning fires once at
  startup.
- With `OLLAMA_API_BASE=https://ollama.com` → no warning, expected
  behavior.

I don't see a vitest setup that covers the refresh path under
`npm test`, so I didn't add automated tests. Open to adding a
fixture-based test against a recorded `/v1/models` payload if that's
useful.

## Reproduction of the original bug

Without this patch:

```sh
export OLLAMA_API_BASE=http://127.0.0.1:11434
# run /ollama-cloud-refresh in pi
# observe: "Registered N Ollama Cloud models" where N matches local pulls
```

With this patch:

```sh
export OLLAMA_API_BASE=http://127.0.0.1:11434
# run /ollama-cloud-refresh in pi
# observe: 34 models register, plus a single console warning at startup
```

Let me know if you'd like the warning surfaced through the UI
instead of `console.warn`, or if you'd prefer the strict approach
(no env-var escape hatch) over the soft approach above. Thanks for
the review.
