### PR TITLE
Fix extension load failure on pi v0.80.x (#35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Resolve `$ENV_VAR` / `${ENV_VAR}` / `!command` expressions in `auth.json` by delegating to pi's own `ModelRegistry.getApiKeyForProvider` via the `ExtensionContext.modelRegistry` handed to each tool's `execute` callback, instead of reading `auth.json` ourselves. The previous `readStoredCredential` path returned the raw stored key without resolution, so the web tools sent literal `$OLLAMA_API_KEY` / `!command` strings as the Bearer token. Delegating to pi's resolver keeps auth resolution semantics authoritative across all pi versions and preserves the `OLLAMA_API_KEY` env-var fallback (needed because pi-ai doesn't map the `ollama-cloud` provider id to `OLLAMA_API_KEY`). Thanks @badlogic for pointing out the `ctx.modelRegistry` hook (`#38`).
 - Fix extension failing to load across pi 0.74.0–0.80.10+ (`#35`). pi removed `AuthStorage` from its public exports and added `readStoredCredential` in the same release (0.80.8); a static named import of either symbol is a hard link-error on the other version range. Replaced the static import with a namespace import + runtime feature detection so the extension loads on both pre-0.80.8 (uses `AuthStorage`) and 0.80.8+ (uses `readStoredCredential`), preserving the `OLLAMA_API_KEY` env-var fallback in both paths.
 
 ## [0.6.0] - 2026-06-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+- Fix extension failing to load across pi 0.74.0–0.80.10+ (`#35`). pi removed `AuthStorage` from its public exports and added `readStoredCredential` in the same release (0.80.8); a static named import of either symbol is a hard link-error on the other version range. Replaced the static import with a namespace import + runtime feature detection so the extension loads on both pre-0.80.8 (uses `AuthStorage`) and 0.80.8+ (uses `readStoredCredential`), preserving the `OLLAMA_API_KEY` env-var fallback in both paths.
+
 ## [0.6.0] - 2026-06-05
 
 - Fix `apiKey` registered as a literal string instead of an environment variable reference. Changed `apiKey: "OLLAMA_API_KEY"` to `apiKey: "$OLLAMA_API_KEY"` in `registerProvider`, resolving the deprecation warning emitted by pi v0.77.0+ and making the `OLLAMA_API_KEY` env var work alongside `auth.json` (env var takes priority, falls back to `auth.json`). Thanks @mandusm (#21).

--- a/test/web-tools.test.ts
+++ b/test/web-tools.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getCloudApiKey } from "../web-tools.ts";
+import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
+
+// Minimal stub: only `getApiKeyForProvider` is exercised. The real
+// ModelRegistry reads auth.json and resolves `$VAR`/`!command` via pi's
+// resolveConfigValue; here we stub its return to drive getCloudApiKey's
+// fallback logic (the only behavior this extension owns).
+function stubRegistry(key: string | undefined, opts: { throw?: boolean } = {}): ModelRegistry {
+  return {
+    getApiKeyForProvider: async () => {
+      if (opts.throw) throw new Error("registry boom");
+      return key;
+    },
+  } as unknown as ModelRegistry;
+}
+
+const ENV_BACKUP: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  ENV_BACKUP.OLLAMA_API_KEY = process.env.OLLAMA_API_KEY;
+  delete process.env.OLLAMA_API_KEY;
+});
+
+afterEach(() => {
+  if (ENV_BACKUP.OLLAMA_API_KEY === undefined) delete process.env.OLLAMA_API_KEY;
+  else process.env.OLLAMA_API_KEY = ENV_BACKUP.OLLAMA_API_KEY;
+});
+
+describe("getCloudApiKey", () => {
+  it("returns the key resolved by the model registry", async () => {
+    expect(await getCloudApiKey(stubRegistry("sk-from-auth-json"))).toBe("sk-from-auth-json");
+  });
+
+  it("falls back to OLLAMA_API_KEY when the registry returns undefined", async () => {
+    process.env.OLLAMA_API_KEY = "env-fallback";
+    expect(await getCloudApiKey(stubRegistry(undefined))).toBe("env-fallback");
+  });
+
+  it("falls back to OLLAMA_API_KEY when the registry returns an empty string", async () => {
+    process.env.OLLAMA_API_KEY = "env-fallback";
+    expect(await getCloudApiKey(stubRegistry(""))).toBe("env-fallback");
+  });
+
+  it("falls back to OLLAMA_API_KEY when the registry throws", async () => {
+    process.env.OLLAMA_API_KEY = "env-fallback";
+    expect(await getCloudApiKey(stubRegistry(undefined, { throw: true }))).toBe("env-fallback");
+  });
+
+  it("returns undefined when neither registry nor env has a key", async () => {
+    expect(await getCloudApiKey(stubRegistry(undefined))).toBeUndefined();
+  });
+
+  it("prefers the registry key over OLLAMA_API_KEY", async () => {
+    process.env.OLLAMA_API_KEY = "env-fallback";
+    expect(await getCloudApiKey(stubRegistry("sk-from-auth-json"))).toBe("sk-from-auth-json");
+  });
+});

--- a/web-tools.ts
+++ b/web-tools.ts
@@ -3,12 +3,17 @@
  *
  * Self-contained module. Depends on:
  *   - models.ts       - only for OLLAMA_BASE URL constant
- *   - pi-coding-agent - AuthStorage, ExtensionAPI, keyHint, truncateToVisualLines
+ *   - pi-coding-agent - readStoredCredential, ExtensionAPI, keyHint, truncateToVisualLines
  *   - pi-tui          - Text, truncateToWidth
  * Does NOT depend on provider registration or model fetching internals.
  */
 
-import { AuthStorage, type ExtensionAPI, keyHint, truncateToVisualLines } from "@earendil-works/pi-coding-agent";
+import {
+  type ExtensionAPI,
+  keyHint,
+  readStoredCredential,
+  truncateToVisualLines,
+} from "@earendil-works/pi-coding-agent";
 import { Text, truncateToWidth } from "@earendil-works/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { OLLAMA_BASE } from "./models.ts";
@@ -31,10 +36,10 @@ interface FetchResponse {
 
 // --- Helpers ---
 
-const authStorage = AuthStorage.create();
-
 async function getCloudApiKey(): Promise<string | undefined> {
-  return authStorage.getApiKey("ollama-cloud") ?? process.env.OLLAMA_API_KEY;
+  const cred = readStoredCredential("ollama-cloud");
+  if (cred && cred.type === "api_key" && cred.key) return cred.key;
+  return process.env.OLLAMA_API_KEY;
 }
 
 function noApiKeyError() {

--- a/web-tools.ts
+++ b/web-tools.ts
@@ -7,15 +7,16 @@
  *   - pi-tui          - Text, truncateToWidth
  * Does NOT depend on provider registration or model fetching internals.
  *
- * Auth note: pi removed `AuthStorage` from its public exports in 0.80.8 and
- * added `readStoredCredential` in the same release. A static named import of
- * either symbol is a hard link-error on the other version range, so we use a
- * namespace import and feature-detect at runtime to stay compatible with
- * pi 0.74.0 through 0.80.10+.
+ * Auth note: the tool `execute` callback receives an `ExtensionContext` whose
+ * `modelRegistry` resolves the configured api key for a provider the same way
+ * pi itself does for model calls (`ModelRegistry.getApiKeyForProvider` →
+ * `AuthStorage.getApiKey` → pi's internal `resolveConfigValue`, which handles
+ * `$VAR`/`${VAR}`/`!command`). We delegate to that instead of reading auth.json
+ * ourselves, so pi owns its own resolution semantics across all versions and
+ * the `OLLAMA_API_KEY` env-var fallback is preserved. See issue #38.
  */
 
-import * as piAgent from "@earendil-works/pi-coding-agent";
-import { type ExtensionAPI, keyHint, truncateToVisualLines } from "@earendil-works/pi-coding-agent";
+import { type ExtensionAPI, keyHint, type ModelRegistry, truncateToVisualLines } from "@earendil-works/pi-coding-agent";
 import { Text, truncateToWidth } from "@earendil-works/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { OLLAMA_BASE } from "./models.ts";
@@ -38,47 +39,19 @@ interface FetchResponse {
 
 // --- Helpers ---
 
-// pi exports `readStoredCredential` (>= 0.80.8) and `AuthStorage` (<= 0.80.7);
-// only one is present on any given version. Probe the namespace at runtime
-// rather than importing either by name so the extension loads everywhere.
-type PiAuthModule = {
-  AuthStorage?: {
-    new (): {
-      create(): {
-        getApiKey(provider: string): Promise<string | undefined>;
-      };
-    };
-  };
-  readStoredCredential?: (provider: string) => { type: string; key?: string } | undefined;
-};
-
-async function getCloudApiKey(): Promise<string | undefined> {
-  const mod = piAgent as PiAuthModule & typeof piAgent;
-
-  // pi >= 0.80.8: readStoredCredential (AuthStorage removed)
-  if (typeof mod.readStoredCredential === "function") {
-    try {
-      const cred = mod.readStoredCredential("ollama-cloud");
-      if (cred && cred.type === "api_key" && cred.key) return cred.key;
-    } catch (e) {
-      console.debug("ollama-cloud: readStoredCredential probe failed:", e);
-    }
+// Resolve the Ollama Cloud api key via pi's own ModelRegistry, which reads
+// auth.json and resolves `$VAR`/`${VAR}`/`!command` exactly as pi does for
+// model calls. `getApiKeyForProvider` uses `includeFallback: false`, so it does
+// NOT consult env vars / custom provider fallback; and pi-ai doesn't map the
+// "ollama-cloud" provider id to OLLAMA_API_KEY anyway, so keep the explicit
+// env fallback. (#24, #38, #48)
+export async function getCloudApiKey(modelRegistry: ModelRegistry): Promise<string | undefined> {
+  try {
+    const key = await modelRegistry.getApiKeyForProvider("ollama-cloud");
+    if (key) return key;
+  } catch (e) {
+    console.debug("ollama-cloud: getApiKeyForProvider failed:", e);
   }
-
-  // pi <= 0.80.7: AuthStorage still exported
-  if (mod.AuthStorage) {
-    try {
-      const authStorage = mod.AuthStorage.create();
-      // getApiKey is async (resolves env vars, $VAR, !command, OAuth refresh).
-      const key = await authStorage.getApiKey("ollama-cloud");
-      if (key) return key;
-    } catch (e) {
-      console.debug("ollama-cloud: AuthStorage probe failed:", e);
-    }
-  }
-
-  // pi-ai doesn't know the "ollama-cloud" provider id, so neither auth path
-  // sees OLLAMA_API_KEY — keep the explicit env fallback for both. (#24/#48)
   return process.env.OLLAMA_API_KEY;
 }
 
@@ -173,8 +146,8 @@ export function registerWebSearchTool(pi: ExtensionAPI) {
         }),
       ),
     }),
-    async execute(_toolCallId, params, signal, _onUpdate, _ctx) {
-      const apiKey = await getCloudApiKey();
+    async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+      const apiKey = await getCloudApiKey(ctx.modelRegistry);
       if (!apiKey) return noApiKeyError();
 
       try {
@@ -255,8 +228,8 @@ export function registerWebFetchTool(pi: ExtensionAPI) {
     parameters: Type.Object({
       url: Type.String({ description: "URL to fetch and extract content from", format: "uri" }),
     }),
-    async execute(_toolCallId, params, signal, _onUpdate, _ctx) {
-      const apiKey = await getCloudApiKey();
+    async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+      const apiKey = await getCloudApiKey(ctx.modelRegistry);
       if (!apiKey) return noApiKeyError();
 
       try {

--- a/web-tools.ts
+++ b/web-tools.ts
@@ -3,17 +3,19 @@
  *
  * Self-contained module. Depends on:
  *   - models.ts       - only for OLLAMA_BASE URL constant
- *   - pi-coding-agent - readStoredCredential, ExtensionAPI, keyHint, truncateToVisualLines
+ *   - pi-coding-agent - ExtensionAPI, keyHint, truncateToVisualLines
  *   - pi-tui          - Text, truncateToWidth
  * Does NOT depend on provider registration or model fetching internals.
+ *
+ * Auth note: pi removed `AuthStorage` from its public exports in 0.80.8 and
+ * added `readStoredCredential` in the same release. A static named import of
+ * either symbol is a hard link-error on the other version range, so we use a
+ * namespace import and feature-detect at runtime to stay compatible with
+ * pi 0.74.0 through 0.80.10+.
  */
 
-import {
-  type ExtensionAPI,
-  keyHint,
-  readStoredCredential,
-  truncateToVisualLines,
-} from "@earendil-works/pi-coding-agent";
+import * as piAgent from "@earendil-works/pi-coding-agent";
+import { type ExtensionAPI, keyHint, truncateToVisualLines } from "@earendil-works/pi-coding-agent";
 import { Text, truncateToWidth } from "@earendil-works/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { OLLAMA_BASE } from "./models.ts";
@@ -36,9 +38,47 @@ interface FetchResponse {
 
 // --- Helpers ---
 
+// pi exports `readStoredCredential` (>= 0.80.8) and `AuthStorage` (<= 0.80.7);
+// only one is present on any given version. Probe the namespace at runtime
+// rather than importing either by name so the extension loads everywhere.
+type PiAuthModule = {
+  AuthStorage?: {
+    new (): {
+      create(): {
+        getApiKey(provider: string): Promise<string | undefined>;
+      };
+    };
+  };
+  readStoredCredential?: (provider: string) => { type: string; key?: string } | undefined;
+};
+
 async function getCloudApiKey(): Promise<string | undefined> {
-  const cred = readStoredCredential("ollama-cloud");
-  if (cred && cred.type === "api_key" && cred.key) return cred.key;
+  const mod = piAgent as PiAuthModule & typeof piAgent;
+
+  // pi >= 0.80.8: readStoredCredential (AuthStorage removed)
+  if (typeof mod.readStoredCredential === "function") {
+    try {
+      const cred = mod.readStoredCredential("ollama-cloud");
+      if (cred && cred.type === "api_key" && cred.key) return cred.key;
+    } catch (e) {
+      console.debug("ollama-cloud: readStoredCredential probe failed:", e);
+    }
+  }
+
+  // pi <= 0.80.7: AuthStorage still exported
+  if (mod.AuthStorage) {
+    try {
+      const authStorage = mod.AuthStorage.create();
+      // getApiKey is async (resolves env vars, $VAR, !command, OAuth refresh).
+      const key = await authStorage.getApiKey("ollama-cloud");
+      if (key) return key;
+    } catch (e) {
+      console.debug("ollama-cloud: AuthStorage probe failed:", e);
+    }
+  }
+
+  // pi-ai doesn't know the "ollama-cloud" provider id, so neither auth path
+  // sees OLLAMA_API_KEY — keep the explicit env fallback for both. (#24/#48)
   return process.env.OLLAMA_API_KEY;
 }
 


### PR DESCRIPTION
AuthStorage was removed from @earendil-works/pi-coding-agent public exports, so import { AuthStorage } resolved to undefined and AuthStorage.create() threw "Cannot read properties of undefined (reading 'create')". Replace with readStoredCredential (still exported) for one-off synchronous reads of auth.json.

Fixes: https://github.com/fgrehm/pi-ollama-cloud/issues/34

Fixes: https://github.com/fgrehm/pi-ollama-cloud/issues/35
