### PR TITLE
fix(web-tools): resolve $VAR/${VAR}/!command in auth.json on readStoredCredential path (#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Resolve `$ENV_VAR` / `${ENV_VAR}` / `!command` expressions in `auth.json` on the `readStoredCredential` path (pi 0.80.8+). pi removed the resolving `AuthStorage.getApiKey()` accessor in 0.80.8 and `readStoredCredential` returns the raw stored key; its internal `resolveConfigValue` is not a public export, so the web tools were sending literal `$OLLAMA_API_KEY` / `!pass ...` strings as the Bearer token. Ported pi's 0.80.8 `resolveConfigValue` semantics (template parser + two-tier shell execution) locally and run it on the `readStoredCredential` branch, mirroring what `AuthStorage` did on 0.74.0–0.80.7. The `AuthStorage` path is unchanged; `getShellConfig` is feature-detected off the existing namespace import (load-safe across versions). Added the first tests for the web-tools auth path (`test/web-tools.test.ts`) (`#38`).
 - Fix extension failing to load across pi 0.74.0–0.80.10+ (`#35`). pi removed `AuthStorage` from its public exports and added `readStoredCredential` in the same release (0.80.8); a static named import of either symbol is a hard link-error on the other version range. Replaced the static import with a namespace import + runtime feature detection so the extension loads on both pre-0.80.8 (uses `AuthStorage`) and 0.80.8+ (uses `readStoredCredential`), preserving the `OLLAMA_API_KEY` env-var fallback in both paths.
 
 ## [0.6.0] - 2026-06-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+- Fix extension failing to load across pi 0.74.0–0.80.10+ (`#35`). pi removed `AuthStorage` from its public exports and added `readStoredCredential` in the same release (0.80.8); a static named import of either symbol is a hard link-error on the other version range. Replaced the static import with a namespace import + runtime feature detection so the extension loads on both pre-0.80.8 (uses `AuthStorage`) and 0.80.8+ (uses `readStoredCredential`), preserving the `OLLAMA_API_KEY` env-var fallback in both paths.
+
 ## [0.6.0] - 2026-06-05
 
 - Fix `apiKey` registered as a literal string instead of an environment variable reference. Changed `apiKey: "OLLAMA_API_KEY"` to `apiKey: "$OLLAMA_API_KEY"` in `registerProvider`, resolving the deprecation warning emitted by pi v0.77.0+ and making the `OLLAMA_API_KEY` env var work alongside `auth.json` (env var takes priority, falls back to `auth.json`). Thanks @mandusm (#21).

--- a/test/web-tools.test.ts
+++ b/test/web-tools.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __clearCommandCache,
+  __setTestAuthOverrides,
+  getCloudApiKey,
+  resolveCredentialKey,
+} from "../web-tools.ts";
+
+// Mock child_process so `!command` tests don't spawn real shells.
+vi.mock("node:child_process", () => ({
+  execSync: vi.fn(),
+  spawnSync: vi.fn(),
+}));
+
+// Import the mocked module to control return values in `!command` tests.
+import { execSync } from "node:child_process";
+
+const ENV_BACKUP: Record<string, string | undefined> = {};
+
+function saveEnv(...names: string[]) {
+  for (const n of names) ENV_BACKUP[n] = process.env[n];
+}
+function restoreEnv() {
+  for (const [k, v] of Object.entries(ENV_BACKUP)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  ENV_BACKUP.length = 0;
+}
+
+beforeEach(() => {
+  saveEnv("OLLAMA_API_KEY", "MY_VAR", "OTHER_VAR");
+  delete process.env.OLLAMA_API_KEY;
+  delete process.env.MY_VAR;
+  delete process.env.OTHER_VAR;
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  __clearCommandCache();
+  __setTestAuthOverrides({});
+  restoreEnv();
+});
+
+describe("resolveCredentialKey — literals", () => {
+  it("returns a plain literal key unchanged", () => {
+    expect(resolveCredentialKey("sk-literal-123")).toBe("sk-literal-123");
+  });
+
+  it("returns undefined for an empty string", () => {
+    expect(resolveCredentialKey("")).toBeUndefined();
+  });
+
+  it("treats a bare env-var-name (no $) as a literal", () => {
+    process.env.MY_VAR = "secret-from-env";
+    // 0.80.8 semantics: no `$` prefix => literal, NOT an env reference.
+    expect(resolveCredentialKey("MY_VAR")).toBe("MY_VAR");
+  });
+});
+
+describe("resolveCredentialKey — $VAR / ${VAR} templates", () => {
+  it("resolves $VAR when the env var is set", () => {
+    process.env.MY_VAR = "resolved-value";
+    expect(resolveCredentialKey("$MY_VAR")).toBe("resolved-value");
+  });
+
+  it("resolves ${VAR} when the env var is set", () => {
+    process.env.MY_VAR = "resolved-value";
+    expect(resolveCredentialKey("${MY_VAR}")).toBe("resolved-value");
+  });
+
+  it("returns undefined when $VAR env var is missing (so the env fallback is reachable)", () => {
+    expect(resolveCredentialKey("$MISSING_VAR")).toBeUndefined();
+  });
+
+  it("returns undefined when ${VAR} env var is missing", () => {
+    expect(resolveCredentialKey("${MISSING_VAR}")).toBeUndefined();
+  });
+
+  it("interpolates $VAR inside a larger string", () => {
+    process.env.MY_VAR = "mid";
+    expect(resolveCredentialKey("prefix-$MY_VAR-suffix")).toBe("prefix-mid-suffix");
+  });
+
+  it("handles $$ as a literal $ and $! as a literal !", () => {
+    expect(resolveCredentialKey("a$$b")).toBe("a$b");
+    expect(resolveCredentialKey("cost$!5")).toBe("cost!5");
+  });
+});
+
+describe("resolveCredentialKey — !command", () => {
+  it("executes a !command and returns trimmed stdout", () => {
+    vi.mocked(execSync).mockReturnValue("command-output\n");
+    expect(resolveCredentialKey("!echo hi")).toBe("command-output");
+  });
+
+  it("returns undefined when the command fails", () => {
+    vi.mocked(execSync).mockImplementation(() => {
+      throw new Error("boom");
+    });
+    expect(resolveCredentialKey("!false")).toBeUndefined();
+  });
+
+  it("caches command results for the lifetime of the process", () => {
+    vi.mocked(execSync).mockReturnValue("first\n");
+    expect(resolveCredentialKey("!my-cmd")).toBe("first");
+    // Second call should hit the cache (execSync not called again).
+    vi.mocked(execSync).mockReturnValue("second\n");
+    expect(resolveCredentialKey("!my-cmd")).toBe("first");
+  });
+});
+
+describe("getCloudApiKey — readStoredCredential path (0.80.8+)", () => {
+  it("resolves a $VAR credential before sending it", async () => {
+    process.env.OLLAMA_API_KEY = "env-fallback";
+    __setTestAuthOverrides({
+      readStoredCredential: () => ({ type: "api_key", key: "$OLLAMA_API_KEY" }),
+    });
+    // No env var named OLLAMA_API_KEY-as-stored... wait, the stored key is the
+    // template "$OLLAMA_API_KEY" which resolves process.env["OLLAMA_API_KEY"].
+    expect(await getCloudApiKey()).toBe("env-fallback");
+  });
+
+  it("falls back to process.env.OLLAMA_API_KEY when the $VAR is missing", async () => {
+    process.env.OLLAMA_API_KEY = "env-fallback";
+    __setTestAuthOverrides({
+      readStoredCredential: () => ({ type: "api_key", key: "$TOTALLY_MISSING" }),
+      AuthStorage: undefined,
+    });
+    expect(await getCloudApiKey()).toBe("env-fallback");
+  });
+
+  it("returns a literal credential", async () => {
+    __setTestAuthOverrides({
+      readStoredCredential: () => ({ type: "api_key", key: "sk-literal" }),
+      AuthStorage: undefined,
+    });
+    expect(await getCloudApiKey()).toBe("sk-literal");
+  });
+
+  it("falls through to env fallback when credential is missing entirely", async () => {
+    process.env.OLLAMA_API_KEY = "env-fallback";
+    __setTestAuthOverrides({ readStoredCredential: () => undefined, AuthStorage: undefined });
+    expect(await getCloudApiKey()).toBe("env-fallback");
+  });
+
+  it("returns undefined when every path is empty", async () => {
+    __setTestAuthOverrides({ readStoredCredential: () => undefined, AuthStorage: undefined });
+    expect(await getCloudApiKey()).toBeUndefined();
+  });
+
+  it("ignores OAuth credentials and falls through to env fallback", async () => {
+    process.env.OLLAMA_API_KEY = "env-fallback";
+    __setTestAuthOverrides({
+      readStoredCredential: () => ({ type: "oauth", access_token: "token", expires: 0 }),
+      AuthStorage: undefined,
+    });
+    expect(await getCloudApiKey()).toBe("env-fallback");
+  });
+});

--- a/web-tools.ts
+++ b/web-tools.ts
@@ -3,12 +3,17 @@
  *
  * Self-contained module. Depends on:
  *   - models.ts       - only for OLLAMA_BASE URL constant
- *   - pi-coding-agent - AuthStorage, ExtensionAPI, keyHint, truncateToVisualLines
+ *   - pi-coding-agent - readStoredCredential, ExtensionAPI, keyHint, truncateToVisualLines
  *   - pi-tui          - Text, truncateToWidth
  * Does NOT depend on provider registration or model fetching internals.
  */
 
-import { AuthStorage, type ExtensionAPI, keyHint, truncateToVisualLines } from "@earendil-works/pi-coding-agent";
+import {
+  type ExtensionAPI,
+  keyHint,
+  readStoredCredential,
+  truncateToVisualLines,
+} from "@earendil-works/pi-coding-agent";
 import { Text, truncateToWidth } from "@earendil-works/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { OLLAMA_BASE } from "./models.ts";
@@ -31,10 +36,10 @@ interface FetchResponse {
 
 // --- Helpers ---
 
-const authStorage = AuthStorage.create();
-
 async function getCloudApiKey(): Promise<string | undefined> {
-  return authStorage.getApiKey("ollama-cloud") ?? process.env.OLLAMA_API_KEY;
+  const cred = readStoredCredential("ollama-cloud");
+  if (cred && cred.type === "api_key" && cred.key) return cred.key;
+  return process.env.OLLAMA_API_KEY;
 }
 
 function noApiKeyError() {

--- a/web-tools.ts
+++ b/web-tools.ts
@@ -12,8 +12,22 @@
  * either symbol is a hard link-error on the other version range, so we use a
  * namespace import and feature-detect at runtime to stay compatible with
  * pi 0.74.0 through 0.80.10+.
+ *
+ * `readStoredCredential` returns the raw stored credential WITHOUT resolving
+ * config-value references (env vars, `!command`). On pi <= 0.80.7 the
+ * `AuthStorage.getApiKey()` path resolved them internally via pi's private
+ * `resolveConfigValue`; on pi >= 0.80.8 that path is gone and `resolveConfigValue`
+ * is NOT a public export, so we port pi's 0.80.8 resolver semantics locally
+ * (`resolveCredentialKey`) and run it on the `readStoredCredential` branch.
+ * The `AuthStorage` branch is unchanged and delegates to pi. See issue #38.
+ *
+ * Limitation: on pi >= 0.80.8, OAuth credentials (`type: "oauth"`) in auth.json
+ * are NOT supported by the `readStoredCredential` path (only `type: "api_key"`),
+ * because `AuthStorage`'s OAuth refresh is gone. Use a literal api_key or the
+ * `OLLAMA_API_KEY` env var for OAuth providers. (#38)
  */
 
+import { execSync, spawnSync } from "node:child_process";
 import * as piAgent from "@earendil-works/pi-coding-agent";
 import { type ExtensionAPI, keyHint, truncateToVisualLines } from "@earendil-works/pi-coding-agent";
 import { Text, truncateToWidth } from "@earendil-works/pi-tui";
@@ -50,26 +64,198 @@ type PiAuthModule = {
     };
   };
   readStoredCredential?: (provider: string) => { type: string; key?: string } | undefined;
+  // getShellConfig is publicly exported on all pi versions; feature-detected off
+  // the namespace so we never add a load-time static-import dependency.
+  getShellConfig?: () => { shell: string; args: string[] };
 };
 
-async function getCloudApiKey(): Promise<string | undefined> {
-  const mod = piAgent as PiAuthModule & typeof piAgent;
+// --- Config-value resolver (port of pi 0.80.8 resolveConfigValue semantics) ---
+//
+// pi's resolveConfigValue is internal (dist/core/resolve-config-value.js) and
+// not re-exported from the public entrypoint on any version, so the extension
+// cannot import it. This faithful port mirrors pi 0.80.8 exactly so the
+// `readStoredCredential` path (0.80.8+) behaves identically to what
+// `AuthStorage.getApiKey()` did on 0.74.0-0.80.7. See issue #38.
 
-  // pi >= 0.80.8: readStoredCredential (AuthStorage removed)
-  if (typeof mod.readStoredCredential === "function") {
+const ENV_VAR_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const ENV_VAR_NAME_PREFIX_RE = /^[A-Za-z_][A-Za-z0-9_]*/;
+
+type TemplatePart = { type: "literal"; value: string } | { type: "env"; name: string };
+
+// Cache for shell command results (process lifetime). Mirrors pi's
+// `commandResultCache` in resolve-config-value.ts. Cleared in tests via
+// `__clearCommandCache`.
+const commandResultCache = new Map<string, string | undefined>();
+
+function appendLiteral(parts: TemplatePart[], value: string): void {
+  if (!value) return;
+  const prev = parts[parts.length - 1];
+  if (prev?.type === "literal") {
+    prev.value += value;
+    return;
+  }
+  parts.push({ type: "literal", value });
+}
+
+// Port of pi's parseConfigValueTemplate: `$VAR`, `${VAR}`, `$$`/`$!` escapes,
+// otherwise literal.
+function parseConfigValueTemplate(config: string): TemplatePart[] {
+  const parts: TemplatePart[] = [];
+  let index = 0;
+  while (index < config.length) {
+    const dollarIndex = config.indexOf("$", index);
+    if (dollarIndex < 0) {
+      appendLiteral(parts, config.slice(index));
+      break;
+    }
+    appendLiteral(parts, config.slice(index, dollarIndex));
+    const nextChar = config[dollarIndex + 1];
+
+    if (nextChar === "$" || nextChar === "!") {
+      appendLiteral(parts, nextChar);
+      index = dollarIndex + 2;
+      continue;
+    }
+    if (nextChar === "{") {
+      const endIndex = config.indexOf("}", dollarIndex + 2);
+      if (endIndex < 0) {
+        appendLiteral(parts, "$");
+        index = dollarIndex + 1;
+        continue;
+      }
+      const name = config.slice(dollarIndex + 2, endIndex);
+      if (ENV_VAR_NAME_RE.test(name)) parts.push({ type: "env", name });
+      else appendLiteral(parts, config.slice(dollarIndex, endIndex + 1));
+      index = endIndex + 1;
+      continue;
+    }
+    const match = config.slice(dollarIndex + 1).match(ENV_VAR_NAME_PREFIX_RE);
+    if (match) {
+      parts.push({ type: "env", name: match[0] });
+      index = dollarIndex + 1 + match[0].length;
+      continue;
+    }
+    appendLiteral(parts, "$");
+    index = dollarIndex + 1;
+  }
+  return parts;
+}
+
+function resolveTemplate(parts: TemplatePart[]): string | undefined {
+  let resolved = "";
+  for (const part of parts) {
+    if (part.type === "literal") {
+      resolved += part.value;
+      continue;
+    }
+    const envValue = process.env[part.name];
+    if (envValue === undefined) return undefined; // missing env var => undefined (env fallback reachable)
+    resolved += envValue;
+  }
+  return resolved;
+}
+
+/** Resolve a raw auth.json key the way pi's resolveConfigValue does on 0.80.8+,
+ *  without importing the non-public internal. Exported for unit testing. */
+export function resolveCredentialKey(rawKey: string): string | undefined {
+  if (!rawKey) return undefined;
+  if (rawKey.startsWith("!")) return executeCommand(rawKey);
+  return resolveTemplate(parseConfigValueTemplate(rawKey));
+}
+
+// Mirrors pi's executeCommandUncached (resolve-config-value.ts) exactly:
+//  win32: getShellConfig (bash) with execSync fallback; unix: execSync.
+function executeCommandUncached(command: string): string | undefined {
+  const mod = piAgent as PiAuthModule & typeof piAgent;
+  if (process.platform === "win32" && typeof mod.getShellConfig === "function") {
     try {
-      const cred = mod.readStoredCredential("ollama-cloud");
-      if (cred && cred.type === "api_key" && cred.key) return cred.key;
+      const { shell, args } = mod.getShellConfig();
+      const r = spawnSync(shell, [...args, command], {
+        encoding: "utf-8",
+        timeout: 10_000,
+        stdio: ["ignore", "pipe", "ignore"],
+        shell: false,
+        windowsHide: true,
+      });
+      if (!r.error && r.status === 0) return (r.stdout ?? "").trim() || undefined;
+      // executed-but-failed -> fall through to execSync, like pi.
+    } catch {
+      // getShellConfig threw (e.g. no bash on win32) -> fall through to execSync.
+    }
+  }
+  try {
+    const out = execSync(command, {
+      encoding: "utf-8",
+      timeout: 10_000,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return out.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function executeCommand(commandConfig: string): string | undefined {
+  if (commandResultCache.has(commandConfig)) return commandResultCache.get(commandConfig);
+  const result = executeCommandUncached(commandConfig.slice(1));
+  commandResultCache.set(commandConfig, result);
+  return result;
+}
+
+/** Clear the shell-command cache. Exported for tests. */
+export function __clearCommandCache(): void {
+  commandResultCache.clear();
+}
+
+// Test seam: when `_authOverridesActive` is true, the stored override values (which
+// may be undefined) fully replace the namespace-detected accessors. This lets tests
+// exercise the readStoredCredential path even on pi 0.74.0 (where mod.AuthStorage
+// is present and would otherwise read the real auth.json).
+let _testReadStoredCredential: PiAuthModule["readStoredCredential"] | undefined;
+let _testAuthStorage: PiAuthModule["AuthStorage"] | undefined;
+let _authOverridesActive = false;
+
+/** @internal Test seam. Passing `undefined` for an accessor disables it. */
+export function __setTestAuthOverrides(overrides: {
+  readStoredCredential?: PiAuthModule["readStoredCredential"];
+  AuthStorage?: PiAuthModule["AuthStorage"];
+}) {
+  _testReadStoredCredential = overrides.readStoredCredential;
+  _testAuthStorage = overrides.AuthStorage;
+  _authOverridesActive = true;
+}
+
+/** @internal Reset the test seam to use the real namespace accessors. */
+export function __clearTestAuthOverrides() {
+  _testReadStoredCredential = undefined;
+  _testAuthStorage = undefined;
+  _authOverridesActive = false;
+}
+
+export async function getCloudApiKey(): Promise<string | undefined> {
+  const mod = piAgent as PiAuthModule & typeof piAgent;
+  const readStoredCredential = _authOverridesActive ? _testReadStoredCredential : mod.readStoredCredential;
+  const AuthStorage = _authOverridesActive ? _testAuthStorage : mod.AuthStorage;
+
+  // pi >= 0.80.8: readStoredCredential (raw read — resolve locally, 0.80.8 semantics)
+  if (typeof readStoredCredential === "function") {
+    try {
+      const cred = readStoredCredential("ollama-cloud");
+      if (cred && cred.type === "api_key" && cred.key) {
+        const resolved = resolveCredentialKey(cred.key);
+        if (resolved) return resolved;
+        // unresolved (missing env var / failed command) -> fall through to AuthStorage / env
+      }
+      // OAuth (type !== "api_key") falls through — see limitation in file header. (#38)
     } catch (e) {
       console.debug("ollama-cloud: readStoredCredential probe failed:", e);
     }
   }
 
-  // pi <= 0.80.7: AuthStorage still exported
-  if (mod.AuthStorage) {
+  // pi <= 0.80.7: AuthStorage still exported (resolves env vars, $VAR, !command, OAuth refresh).
+  if (AuthStorage) {
     try {
-      const authStorage = mod.AuthStorage.create();
-      // getApiKey is async (resolves env vars, $VAR, !command, OAuth refresh).
+      const authStorage = AuthStorage.create();
       const key = await authStorage.getApiKey("ollama-cloud");
       if (key) return key;
     } catch (e) {

--- a/web-tools.ts
+++ b/web-tools.ts
@@ -3,17 +3,19 @@
  *
  * Self-contained module. Depends on:
  *   - models.ts       - only for OLLAMA_BASE URL constant
- *   - pi-coding-agent - readStoredCredential, ExtensionAPI, keyHint, truncateToVisualLines
+ *   - pi-coding-agent - ExtensionAPI, keyHint, truncateToVisualLines
  *   - pi-tui          - Text, truncateToWidth
  * Does NOT depend on provider registration or model fetching internals.
+ *
+ * Auth note: pi removed `AuthStorage` from its public exports in 0.80.8 and
+ * added `readStoredCredential` in the same release. A static named import of
+ * either symbol is a hard link-error on the other version range, so we use a
+ * namespace import and feature-detect at runtime to stay compatible with
+ * pi 0.74.0 through 0.80.10+.
  */
 
-import {
-  type ExtensionAPI,
-  keyHint,
-  readStoredCredential,
-  truncateToVisualLines,
-} from "@earendil-works/pi-coding-agent";
+import * as piAgent from "@earendil-works/pi-coding-agent";
+import { type ExtensionAPI, keyHint, truncateToVisualLines } from "@earendil-works/pi-coding-agent";
 import { Text, truncateToWidth } from "@earendil-works/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { OLLAMA_BASE } from "./models.ts";
@@ -36,9 +38,47 @@ interface FetchResponse {
 
 // --- Helpers ---
 
+// pi exports `readStoredCredential` (>= 0.80.8) and `AuthStorage` (<= 0.80.7);
+// only one is present on any given version. Probe the namespace at runtime
+// rather than importing either by name so the extension loads everywhere.
+type PiAuthModule = {
+  AuthStorage?: {
+    new (): {
+      create(): {
+        getApiKey(provider: string): Promise<string | undefined>;
+      };
+    };
+  };
+  readStoredCredential?: (provider: string) => { type: string; key?: string } | undefined;
+};
+
 async function getCloudApiKey(): Promise<string | undefined> {
-  const cred = readStoredCredential("ollama-cloud");
-  if (cred && cred.type === "api_key" && cred.key) return cred.key;
+  const mod = piAgent as PiAuthModule & typeof piAgent;
+
+  // pi >= 0.80.8: readStoredCredential (AuthStorage removed)
+  if (typeof mod.readStoredCredential === "function") {
+    try {
+      const cred = mod.readStoredCredential("ollama-cloud");
+      if (cred && cred.type === "api_key" && cred.key) return cred.key;
+    } catch (e) {
+      console.debug("ollama-cloud: readStoredCredential probe failed:", e);
+    }
+  }
+
+  // pi <= 0.80.7: AuthStorage still exported
+  if (mod.AuthStorage) {
+    try {
+      const authStorage = mod.AuthStorage.create();
+      // getApiKey is async (resolves env vars, $VAR, !command, OAuth refresh).
+      const key = await authStorage.getApiKey("ollama-cloud");
+      if (key) return key;
+    } catch (e) {
+      console.debug("ollama-cloud: AuthStorage probe failed:", e);
+    }
+  }
+
+  // pi-ai doesn't know the "ollama-cloud" provider id, so neither auth path
+  // sees OLLAMA_API_KEY — keep the explicit env fallback for both. (#24/#48)
   return process.env.OLLAMA_API_KEY;
 }
 


### PR DESCRIPTION
## Summary

Fixes #38. On pi 0.80.8+, `readStoredCredential` returns the raw stored credential without resolving config-value references, so the web tools (`ollama_web_search` / `ollama_web_fetch`) sent literal `"$OLLAMA_API_KEY"` / `"!command"` strings as the Bearer token and the `process.env.OLLAMA_API_KEY` fallback was never reached (early truthy return on the raw literal).

The full validation against the pi codebase (v0.80.8 + main) is in [this issue comment](https://github.com/fgrehm/pi-ollama-cloud/issues/38#issuecomment-5006625120). TL;DR:

- ✅ Bug confirmed — `web-tools.ts` returned `cred.key` raw from the `readStoredCredential` branch.
- ⚠️ `$` IS required for env-var resolution on 0.80.8+ (the resolver gained a `parseConfigValueTemplate` parser; a bare `OLLAMA_API_KEY` is a literal, `$OLLAMA_API_KEY` resolves). The issue's `$OLLAMA_API_KEY` example is correct current syntax.
- ❌ The issue's suggested `import { resolveConfigValue }` is invalid — it is not a public export on any version, and a deep import is blocked by the package `exports` map (`ERR_MODULE_NOT_FOUND`).
- 🔍 No public reuse path exists on 0.80.8+:
  - `readStoredCredential()` is documented as *"without resolving configured key values"*.
  - `AuthStorage` (whose `read()` resolved via `resolveConfigValue`) was de-exported from `index.ts`.
  - `ModelRuntime.getAuth()` returns a resolved key but has a `private constructor` and no exported factory — an extension can't construct one.
  - `ExtensionAPI` exposes only `registerProvider`/`unregisterProvider`; there is no `getAuth`/`getApiKey`/`getCredential`/`getModelRuntime` hook for an extension to ask the host for a resolved key.

## What changed

Ported pi 0.80.8's exact `resolveConfigValue` semantics into `web-tools.ts` as a local `resolveCredentialKey` (~60 lines: `parseConfigValueTemplate` template parser + two-tier `executeCommand` shell fallback with process-lifetime cache). Run it only on the `readStoredCredential` branch (0.80.8+); the `AuthStorage` branch (0.74.0–0.80.7) delegates to pi unchanged. `getShellConfig` is feature-detected off the existing `piAgent` namespace import (no new static import → load-safe across all pi versions).

Behavioral parity with pi 0.80.8:

| Input class | Behavior |
|---|---|
| `sk-literal` | returned unchanged |
| `$VAR` / `${VAR}` (set) | resolved from `process.env` |
| `$VAR` / `${VAR}` (missing) | `undefined` → **env fallback reachable again** |
| `$$` / `$!` | literal `$` / `!` |
| `!command` | executed (win32: `getShellConfig`+bash, else `execSync`), stdout trimmed, cached |
| `!command` failure | `undefined` → env fallback |

**Bonus:** mirroring 0.80.8 exactly means a missing env var returns `undefined` (not the literal), so the `process.env.OLLAMA_API_KEY` fallback becomes reachable again — the pre-existing fallthrough gap is fixed for free.

**Limitation:** on pi 0.80.8+, OAuth credentials (`type: "oauth"`) in `auth.json` are not supported by the `readStoredCredential` path (only `type: "api_key"`), because `AuthStorage`'s OAuth refresh is gone. Use a literal api_key or the `OLLAMA_API_KEY` env var for OAuth providers. Documented in the file header.

### Files
- `web-tools.ts` — added `resolveCredentialKey` + `parseConfigValueTemplate` + `resolveTemplate` + `executeCommand`(cached)/`executeCommandUncached`; rewrote the `readStoredCredential` branch to resolve; added test seams (`__setTestAuthOverrides` / `__clearTestAuthOverrides` / `__clearCommandCache`).
- `test/web-tools.test.ts` — new. First tests for the auth path: literal, `$VAR`/`${VAR}` set+missing, `$$`/`$!` escapes, `!command` success/failure/cache (mocked `child_process`), OAuth fallthrough, empty/missing cred, fallback ordering.
- `CHANGELOG.md` — `[Unreleased]` entry.

## Validation

```
npm test   →  Test Files 2 passed | Tests 54 passed (54)   (36 existing + 18 new)
npm run lint → Checked 9 files. No fixes applied.
```

Refs #38
