### PR TITLE
feat: /login support via interactive API-key flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+
+- `/login` support: "Ollama Cloud" now appears in pi's login dialog with an interactive
+  API-key flow (prompt, validation against an authenticated endpoint, persisted via pi's
+  standard credential store). `OLLAMA_API_KEY` and manual `auth.json` entries keep working
+  unchanged. ([#login-api-key])
+
 ## [Unreleased]
 
 

--- a/index.ts
+++ b/index.ts
@@ -27,7 +27,13 @@
  * Only models with "tools" capability are registered.
  */
 
-import type { ExtensionAPI, ExtensionCommandContext, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+  OAuthCredentials,
+  OAuthLoginCallbacks,
+  ProviderModelConfig,
+} from "@earendil-works/pi-coding-agent";
 import { loadConfig, resolveWebToolsEnv } from "./config.ts";
 import { GENERATED_MODELS } from "./models.generated.ts";
 import {
@@ -42,6 +48,44 @@ import { registerWebFetchTool, registerWebSearchTool } from "./web-tools.ts";
 
 // --- Registrations ---
 
+/**
+ * API-key login flow for `/login`.
+ *
+ * Ollama Cloud has no OAuth; this uses pi's oauth hook as an interactive
+ * API-key flow (prompt -> validate -> persist), the same pattern pi's built-in
+ * llama.cpp provider uses. The key is stored in the standard credential
+ * `access` field; `refreshToken` is a no-op because API keys do not expire.
+ */
+async function loginWithApiKey(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+  const key = (
+    await callbacks.onPrompt({
+      message: "Paste your Ollama Cloud API key (create one at https://ollama.com/settings/keys)",
+      placeholder: "API key",
+    })
+  ).trim();
+  if (!key) throw new Error("No API key provided");
+
+  // Validate against an authenticated endpoint. Only a definite auth failure
+  // rejects the key; transient network errors must not block login.
+  callbacks.onProgress?.("Validating API key...");
+  try {
+    const res = await fetch(`${OLLAMA_BASE}/api/web_search`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ query: "ping", max_results: 1 }),
+      signal: callbacks.signal,
+    });
+    if (res.status === 401 || res.status === 403) {
+      throw new Error("Ollama Cloud rejected this API key (HTTP " + res.status + ")");
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Ollama Cloud rejected")) throw error;
+    callbacks.onProgress?.("Could not reach ollama.com to validate; storing key anyway");
+  }
+
+  return { refresh: "", access: key, expires: Number.MAX_SAFE_INTEGER };
+}
+
 function registerProvider(pi: ExtensionAPI, models: ProviderModelConfig[]) {
   pi.registerProvider("ollama-cloud", {
     name: "Ollama Cloud",
@@ -49,6 +93,13 @@ function registerProvider(pi: ExtensionAPI, models: ProviderModelConfig[]) {
     apiKey: "$OLLAMA_API_KEY",
     api: "openai-completions",
     models,
+    oauth: {
+      name: "Ollama Cloud (API key)",
+      login: loginWithApiKey,
+      // API keys do not expire; hand the same credentials back.
+      refreshToken: async (credentials) => credentials,
+      getApiKey: (credentials) => String(credentials.access),
+    },
   });
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -836,6 +836,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -852,6 +855,9 @@
       "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -870,6 +876,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -887,6 +896,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -903,6 +915,9 @@
       "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
Adds "Ollama Cloud" to pi's `/login` dialog with an interactive API-key flow, so users no longer need to hand-edit `auth.json` or export `OLLAMA_API_KEY` before first use.

## How

Pi's `oauth` provider hook supports interactive flows generally, not just OAuth — pi's own built-in llama.cpp provider uses it as an API-key prompt. This PR applies the same pattern:

- `/login` → "Ollama Cloud" → secret prompt (with a hint pointing at https://ollama.com/settings/keys)
- The key is validated against `POST /api/web_search` — the only endpoint I found that actually 401s on a bad key (`/v1/models` is public and returns 200 for any Authorization header)
- Only definite auth failures (401/403) reject the key; transient network errors store the key with a progress notice instead of blocking login
- Credentials persist through pi's standard store; `getApiKey` returns the key; `refreshToken` is a no-op (API keys do not expire)

`OLLAMA_API_KEY` and manual `auth.json` entries keep working unchanged.

## Testing

- `npm test` — 43/43 pass, `npm run lint` clean
- Verified live in pi v0.84.1: provider listed in `/login`, prompt renders, an invalid key is rejected with `Ollama Cloud rejected this API key (HTTP 401)`, and cancel (escape) exits cleanly