### PR TITLE
feat: refresh model catalog through pi native pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Changed
+
+- Model catalog now refreshes through pi's native provider refresh pipeline
+  (`refreshModels`), so it updates at startup, when the `/model` picker opens, and
+  right after `/login` — previously a fresh login left the provider on the baked-in
+  model list. Network policy is unchanged: a fresh cache is answered from disk, and
+  a full re-fetch only happens on an explicit refresh or a stale/missing cache.
+- Removed the extension's own `session_start` stale-cache refresh; pi's refresh
+  covers it, so a stale cache no longer triggers a second refresh pass.
+
 ## [Unreleased]
 
 

--- a/index.ts
+++ b/index.ts
@@ -36,11 +36,41 @@ import {
   OLLAMA_BASE,
   type RefreshProgress,
   readCacheState,
+  refreshOllamaCloudModels,
   writeCache,
 } from "./models.ts";
 import { registerWebFetchTool, registerWebSearchTool } from "./web-tools.ts";
 
 // --- Registrations ---
+
+/**
+ * Catalog refresh through pi's native model-refresh pipeline.
+ *
+ * Pi calls this whenever it refreshes model catalogs: at startup, when the
+ * `/model` picker opens, and right after a successful `/login`. That last one
+ * matters most - without this hook a fresh login leaves the provider on the
+ * baked-in list until the user discovers `/ollama-cloud-refresh`.
+ *
+ * The network-cost policy is unchanged. A full refresh is one list call plus
+ * one `/api/show` per model, so this only goes to the network when the caller
+ * forced a refresh or the on-disk cache is stale/missing; a fresh cache is
+ * answered from disk with no requests.
+ */
+async function refreshModelsForPi(
+  context: { allowNetwork: boolean; force?: boolean; signal: AbortSignal },
+  fallback: ProviderModelConfig[],
+): Promise<ProviderModelConfig[]> {
+  // Offline restore phase, or already cancelled: keep the current list.
+  if (!context.allowNetwork || context.signal.aborted) return fallback;
+
+  const cache = readCacheState();
+  if (!context.force && cache.status === "fresh") return assembleModels(cache.models);
+
+  const raw = await refreshOllamaCloudModels({});
+  if (context.signal.aborted) return fallback;
+  writeCache(raw);
+  return assembleModels(raw);
+}
 
 function registerProvider(pi: ExtensionAPI, models: ProviderModelConfig[]) {
   pi.registerProvider("ollama-cloud", {
@@ -49,6 +79,7 @@ function registerProvider(pi: ExtensionAPI, models: ProviderModelConfig[]) {
     apiKey: "$OLLAMA_API_KEY",
     api: "openai-completions",
     models,
+    refreshModels: (context) => refreshModelsForPi(context, models),
   });
 }
 
@@ -120,25 +151,16 @@ function registerRefreshCommand(pi: ExtensionAPI) {
 
 export default async function (pi: ExtensionAPI) {
   const cacheState = readCacheState();
-  // Auto-refresh only when the disk cache is stale (>30 days).
-  // When cache is missing, GENERATED_MODELS serves as the cache —
-  // it is manually generated via `npm run generate-models` and committed to the repo.
-  const needsStartupRefresh = cacheState.status === "stale";
   // GENERATED_MODELS ships with the package. Used when no local cache exists. A
-  // fresh user cache from /ollama-cloud-refresh takes precedence over the generated list.
+  // fresh user cache takes precedence over the generated list.
   const models = cacheState.status === "missing" ? GENERATED_MODELS : assembleModels(cacheState.models);
 
   registerProvider(pi, models);
   registerRefreshCommand(pi);
 
-  if (needsStartupRefresh) {
-    let started = false;
-    pi.on("session_start", async (_event, ctx) => {
-      if (started) return;
-      started = true;
-      await runRefresh(pi, ctx);
-    });
-  }
+  // A stale cache no longer needs its own session_start refresh: refreshModels
+  // runs inside pi's catalog refresh (startup, /model, post-login) and
+  // re-fetches whenever the cache is stale.
 
   // --- Web Tools Management ---
 


### PR DESCRIPTION
Registers the provider's `refreshModels()` hook so the Ollama Cloud catalog updates through pi's own model-refresh pipeline instead of only via `/ollama-cloud-refresh`.

## Why

pi refreshes provider catalogs on its own — at startup, when the `/model` picker opens, and right after a successful `/login` (`Models.refresh()` → each provider's `refreshModels`). The extension never registered that hook, so its catalog only changed when the user found and ran the extension command.

The most visible symptom: **after `/login` the model list stays on the baked-in `GENERATED_MODELS`** — the tagged ids the API actually serves (e.g. `deepseek-v4-flash:0731`, `deepseek-v4-flash:preview`) never appear until the user runs `/ollama-cloud-refresh`. A new user logs in and reasonably concludes the provider is broken.

## What changed

- `registerProvider` now passes `refreshModels: (context) => refreshModelsForPi(context, models)`.
- That function routes through the existing cache, so **the network-cost policy that motivated the manual command is unchanged**:
  - fresh cache → answered from disk, zero requests
  - stale/missing cache, or `context.force` → full re-fetch (list + one `/api/show` per model), cache written
  - offline restore phase (`allowNetwork: false`) or aborted signal → keep the current list
- Removed the extension's own `session_start` stale-cache refresh: pi's refresh covers that case now, and keeping both meant two refresh passes racing on the same stale cache.

`/ollama-cloud-refresh` is untouched and still works — it is now a convenience (forced refresh with the progress widget) rather than the only way to get a current catalog. Happy to deprecate or drop it in a follow-up if you would rather not carry a vendor-specific command; that is your call, so this PR does not remove public surface.

## Testing

Verified against pi v0.84.1 with a real Ollama Cloud key. `npm test` 43/43, `npm run lint` clean.

Scenario: staled the cache timestamp to 60 days and deleted all `deepseek*` entries from it, then started pi.

- Opening `/model` triggered the provider refresh; the cache came back with all 18 models including `deepseek-v4-flash:0731` and `:preview` — no extension command run.
- A session started with the (now fresh) cache lists `deepseek-v4-flash:0731 [ollama-cloud]` in the picker and streams from it normally.
- With a fresh cache, refreshes make no network calls (instrumented and confirmed: the hook returns the cached assembly immediately).

## Known limitation (pi-side, not introduced here)

pi's model-selector aborts a catalog refresh after 15s. A **cold** refresh here is one list call plus 18 `/api/show` calls (~20s), so the first picker-open on a stale cache can exceed that budget: the cache is written, but that session's in-memory list is only updated on the next refresh (next picker-open or next session). Subsequent refreshes are instant because the cache is fresh. Fetching details concurrently with a tighter budget, or persisting via `context.publish({ persist })`, would close this — out of scope here, happy to follow up if you want it.

Independent of #44; if both land, the only conflict is adjacent lines in `registerProvider`.