### PR TITLE
feat(web-tools): cache results, expand search snippets, page long fetches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Add `refresh=true` to `ollama_web_search` and `ollama_web_fetch` to bypass the cache (including a cached failure) and re-call the API; the fresh result replaces the cache entry.
 - Cache `ollama_web_search` results (24h) and `ollama_web_fetch` pages (24h success / 15 min failure) on disk, so repeated queries and page reads cost 0 API calls. Tune with `PI_OLLAMA_SEARCH_TTL_HOURS`, `PI_OLLAMA_SEARCH_FAIL_TTL_MINUTES`, and `PI_OLLAMA_SEARCH_CACHE_PATH`.
 - Truncate search snippets to 500 chars and mark them `[truncated]`/`[complete]`. The full content of each result is cached, and `expand=<index>` returns it without a separate fetch call (0 extra API calls).
 - Add `offset` and `full` parameters to `ollama_web_fetch` for paged reading of long pages (3000-char chunks by default; `PI_OLLAMA_SEARCH_SNIPPET_CHARS`/`PI_OLLAMA_SEARCH_CHUNK_CHARS` to tune), with a `Continue:` hint telling the agent the next offset.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Cache `ollama_web_search` results (24h) and `ollama_web_fetch` pages (24h success / 15 min failure) on disk, so repeated queries and page reads cost 0 API calls. Tune with `PI_OLLAMA_SEARCH_TTL_HOURS`, `PI_OLLAMA_SEARCH_FAIL_TTL_MINUTES`, and `PI_OLLAMA_SEARCH_CACHE_PATH`.
+- Truncate search snippets to 500 chars and mark them `[truncated]`/`[complete]`. The full content of each result is cached, and `expand=<index>` returns it without a separate fetch call (0 extra API calls).
+- Add `offset` and `full` parameters to `ollama_web_fetch` for paged reading of long pages (3000-char chunks by default; `PI_OLLAMA_SEARCH_SNIPPET_CHARS`/`PI_OLLAMA_SEARCH_CHUNK_CHARS` to tune), with a `Continue:` hint telling the agent the next offset.
+- Failed page fetches are negative-cached for 15 min and throw a diagnostic message (likely cause + next steps) instead of a bare error.
+
+
 ## [0.10.0] - 2026-09-03
 
 - **Breaking:** Adapt to the changed `/api/usage` response shape. The endpoint now returns a single `limits.monthly` bucket (replacing `limits.session` and `limits.weekly`) and adds an `activity.models` array. `UsageData`, `isUsageResponse`, `formatUsage`, and `formatUsageStatusColored` now read the monthly limit; the status bar shows a single `30d` segment instead of `5h`/`7d`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ All notable changes to this project will be documented in this file.
 - Cache `ollama_web_search` results (24h) and `ollama_web_fetch` pages (24h success / 15 min failure) on disk, so repeated queries and page reads cost 0 API calls. Tune with `PI_OLLAMA_SEARCH_TTL_HOURS`, `PI_OLLAMA_SEARCH_FAIL_TTL_MINUTES`, and `PI_OLLAMA_SEARCH_CACHE_PATH`.
 - Truncate search snippets to 500 chars and mark them `[truncated]`/`[complete]`. The full content of each result is cached, and `expand=<index>` returns it without a separate fetch call (0 extra API calls).
 - Add `offset` and `full` parameters to `ollama_web_fetch` for paged reading of long pages (3000-char chunks by default; `PI_OLLAMA_SEARCH_SNIPPET_CHARS`/`PI_OLLAMA_SEARCH_CHUNK_CHARS` to tune), with a `Continue:` hint telling the agent the next offset.
-- Failed page fetches are negative-cached for 15 min and throw a diagnostic message (likely cause + next steps) instead of a bare error.
+- Failed page fetches are negative-cached for 15 min and throw a diagnostic message (likely cause + next steps) instead of a bare error. Auth (401/403) and rate-limit (429) failures are not cached and name the API key / retry path instead.
+- Expired cache entries are pruned on write, so the cache file does not grow unbounded.
 
 ## [0.10.0] - 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ All notable changes to this project will be documented in this file.
 - Add `offset` and `full` parameters to `ollama_web_fetch` for paged reading of long pages (3000-char chunks by default; `PI_OLLAMA_SEARCH_SNIPPET_CHARS`/`PI_OLLAMA_SEARCH_CHUNK_CHARS` to tune), with a `Continue:` hint telling the agent the next offset.
 - Failed page fetches are negative-cached for 15 min and throw a diagnostic message (likely cause + next steps) instead of a bare error.
 
-
 ## [0.10.0] - 2026-09-03
 
 - **Breaking:** Adapt to the changed `/api/usage` response shape. The endpoint now returns a single `limits.monthly` bucket (replacing `limits.session` and `limits.weekly`) and adds an `activity.models` array. `UsageData`, `isUsageResponse`, `formatUsage`, and `formatUsageStatusColored` now read the monthly limit; the status bar shows a single `30d` segment instead of `5h`/`7d`.

--- a/README.md
+++ b/README.md
@@ -167,6 +167,41 @@ See [docs/think-experiment.md](docs/think-experiment.md) for the testing methodo
 
 Both tools use the same Ollama Cloud API key configured for the provider. No local Ollama server is needed.
 
+### Caching
+
+Both tools cache results on disk (under the pi agent home, `~/.pi/agent/cache/pi-ollama-cloud/cache.json`). A repeated search query or page fetch within the TTL is served from cache and costs 0 API calls:
+
+- Successful searches and pages: cached for 24h
+- Failed page fetches: negative-cached for 15 min, so retrying a dead page does not re-call the API
+
+### `ollama_web_search`
+
+Returns up to 5 results (title, URL, 500-char snippet). Snippets are marked `[truncated]` when the source is longer than the snippet. Output ends with `# live query` or `# from cache` to show whether the API was called.
+
+The search API returns each result's full content; it is cached in full, so a truncated result can be expanded without a separate fetch:
+
+- `expand=<index>` — return the full content of that result (1-based) from the cached search, 0 extra API calls. If the query was never searched (or the cache expired), the search runs live first.
+- Use `ollama_web_fetch` only when the search result's content is not enough (e.g. you need a different page, or the search excerpt is shorter than the full page).
+
+### `ollama_web_fetch`
+
+Returns the page title, a 3000-char slice of the content, and links. Long pages are read in chunks to keep the context window small:
+
+- `offset=N` — continue reading from character N (the output tells you the next offset)
+- `full=true` — return all remaining content from `offset` in one call
+
+A failed fetch throws a diagnostic message (likely cause + next steps) instead of a bare error.
+
+### Tuning
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `PI_OLLAMA_SEARCH_TTL_HOURS` | `24` | Success cache TTL |
+| `PI_OLLAMA_SEARCH_FAIL_TTL_MINUTES` | `15` | Failure (negative) cache TTL |
+| `PI_OLLAMA_SEARCH_CACHE_PATH` | `<pi agent home>/cache/pi-ollama-cloud/cache.json` | Cache file location |
+| `PI_OLLAMA_SEARCH_SNIPPET_CHARS` | `500` | Search snippet length |
+| `PI_OLLAMA_SEARCH_CHUNK_CHARS` | `3000` | Fetch chunk size |
+
 ## Commands
 
 | Command | Description |

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Both tools cache results on disk (under the pi agent home, `~/.pi/agent/cache/pi
 - Successful searches and pages: cached for 24h
 - Failed page fetches: negative-cached for 15 min, so retrying a dead page does not re-call the API. Auth (401/403) and rate-limit (429) failures are not cached — fixing the key or waiting out the limit lets a retry through immediately
 - Expired entries are pruned the next time the cache is written, so the file does not grow unbounded
+- `refresh=true` on either tool bypasses the cache (including a cached failure) and re-calls the API; the fresh result replaces the cache entry
 
 ### `ollama_web_search`
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ Both tools use the same Ollama Cloud API key configured for the provider. No loc
 Both tools cache results on disk (under the pi agent home, `~/.pi/agent/cache/pi-ollama-cloud/cache.json`). A repeated search query or page fetch within the TTL is served from cache and costs 0 API calls:
 
 - Successful searches and pages: cached for 24h
-- Failed page fetches: negative-cached for 15 min, so retrying a dead page does not re-call the API
+- Failed page fetches: negative-cached for 15 min, so retrying a dead page does not re-call the API. Auth (401/403) and rate-limit (429) failures are not cached — fixing the key or waiting out the limit lets a retry through immediately
+- Expired entries are pruned the next time the cache is written, so the file does not grow unbounded
 
 ### `ollama_web_search`
 

--- a/cache.ts
+++ b/cache.ts
@@ -1,0 +1,88 @@
+/**
+ * Disk-backed cache for the Ollama Cloud web tools.
+ *
+ * Successes live 24h; failures are negative-cached for 15 min so retrying a
+ * dead page costs 0 extra API calls. Same query/URL within TTL is served from
+ * cache.
+ *
+ * Tuning (env vars, read once at module load):
+ *   PI_OLLAMA_SEARCH_TTL_HOURS        success TTL (default 24)
+ *   PI_OLLAMA_SEARCH_FAIL_TTL_MINUTES failure TTL (default 15)
+ *   PI_OLLAMA_SEARCH_CACHE_PATH       cache file location (default <pi agent home>/cache/pi-ollama-cloud/cache.json)
+ */
+
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+
+export const CACHE_PATH =
+  process.env.PI_OLLAMA_SEARCH_CACHE_PATH ?? join(getAgentDir(), "cache", "pi-ollama-cloud", "cache.json");
+export const CACHE_TTL_MS = Number(process.env.PI_OLLAMA_SEARCH_TTL_HOURS ?? 24) * 60 * 60 * 1000;
+export const FAIL_TTL_MS = Number(process.env.PI_OLLAMA_SEARCH_FAIL_TTL_MINUTES ?? 15) * 60 * 1000;
+
+export interface SearchResult {
+  title: string;
+  url: string;
+  /** Full content as returned by the search API (not truncated); display truncation happens in web-tools.ts. */
+  content: string;
+}
+
+export interface SearchCacheEntry {
+  ts: number;
+  q: string;
+  results: SearchResult[];
+}
+
+export interface PageCacheEntry {
+  ts: number;
+  title?: string;
+  content?: string;
+  links?: string[] | null;
+  error?: string;
+}
+
+export interface CacheData {
+  searches: Record<string, SearchCacheEntry>;
+  pages: Record<string, PageCacheEntry>;
+}
+
+let cacheData: CacheData | null = null;
+
+export function loadCache(): CacheData {
+  if (cacheData) return cacheData;
+  try {
+    const raw = JSON.parse(readFileSync(CACHE_PATH, "utf8"));
+    if (raw && typeof raw === "object" && raw.searches && raw.pages) {
+      cacheData = raw as CacheData;
+      return cacheData;
+    }
+  } catch {
+    // first run or corrupt file — start fresh
+  }
+  cacheData = { searches: {}, pages: {} };
+  return cacheData;
+}
+
+export function saveCache(): void {
+  const data = loadCache();
+  try {
+    mkdirSync(dirname(CACHE_PATH), { recursive: true });
+    const tmp = `${CACHE_PATH}.tmp`;
+    writeFileSync(tmp, JSON.stringify(data));
+    renameSync(tmp, CACHE_PATH);
+  } catch {
+    // cache is best-effort; a failed write must not break the tool call
+  }
+}
+
+/** Fresh = entry exists and within TTL. Failed entries get a shorter TTL (retry sooner). */
+export function isFresh(entry: { ts: number; error?: string } | undefined): boolean {
+  if (!entry) return false;
+  const ttl = entry.error ? FAIL_TTL_MS : CACHE_TTL_MS;
+  return Date.now() - entry.ts < ttl;
+}
+
+export function searchCacheKey(query: string, maxResults: number): string {
+  return createHash("sha1").update(`${query}\n${maxResults}`).digest("hex");
+}

--- a/cache.ts
+++ b/cache.ts
@@ -73,6 +73,10 @@ export function loadCache(): CacheData {
 
 export function saveCache(): void {
   const data = loadCache();
+  // Prune expired entries before writing so the file does not grow unbounded.
+  // O(n) scan on every save, negligible at this cache size.
+  for (const [k, e] of Object.entries(data.searches)) if (!isFresh(e)) delete data.searches[k];
+  for (const [k, e] of Object.entries(data.pages)) if (!isFresh(e)) delete data.pages[k];
   try {
     mkdirSync(dirname(CACHE_PATH), { recursive: true });
     const tmp = `${CACHE_PATH}.tmp`;

--- a/cache.ts
+++ b/cache.ts
@@ -75,8 +75,8 @@ export function saveCache(): void {
   const data = loadCache();
   // Prune expired entries before writing so the file does not grow unbounded.
   // O(n) scan on every save, negligible at this cache size.
-  for (const [k, e] of Object.entries(data.searches)) if (!isFresh(e)) delete data.searches[k];
-  for (const [k, e] of Object.entries(data.pages)) if (!isFresh(e)) delete data.pages[k];
+  for (const [key, entry] of Object.entries(data.searches)) if (!isFresh(entry)) delete data.searches[key];
+  for (const [key, entry] of Object.entries(data.pages)) if (!isFresh(entry)) delete data.pages[key];
   try {
     mkdirSync(dirname(CACHE_PATH), { recursive: true });
     const tmp = `${CACHE_PATH}.tmp`;

--- a/cache.ts
+++ b/cache.ts
@@ -15,11 +15,12 @@ import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import { envInt } from "./utils.ts";
 
 export const CACHE_PATH =
   process.env.PI_OLLAMA_SEARCH_CACHE_PATH ?? join(getAgentDir(), "cache", "pi-ollama-cloud", "cache.json");
-export const CACHE_TTL_MS = Number(process.env.PI_OLLAMA_SEARCH_TTL_HOURS ?? 24) * 60 * 60 * 1000;
-export const FAIL_TTL_MS = Number(process.env.PI_OLLAMA_SEARCH_FAIL_TTL_MINUTES ?? 15) * 60 * 1000;
+export const CACHE_TTL_MS = envInt("PI_OLLAMA_SEARCH_TTL_HOURS", 24) * 60 * 60 * 1000;
+export const FAIL_TTL_MS = envInt("PI_OLLAMA_SEARCH_FAIL_TTL_MINUTES", 15) * 60 * 1000;
 
 export interface SearchResult {
   title: string;
@@ -36,6 +37,8 @@ export interface SearchCacheEntry {
 
 export interface PageCacheEntry {
   ts: number;
+  /** HTTP status for failed fetches; drives status-specific diagnostics in web-tools.ts. */
+  status?: number;
   title?: string;
   content?: string;
   links?: string[] | null;
@@ -49,12 +52,16 @@ export interface CacheData {
 
 let cacheData: CacheData | null = null;
 
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
 export function loadCache(): CacheData {
   if (cacheData) return cacheData;
   try {
-    const raw = JSON.parse(readFileSync(CACHE_PATH, "utf8"));
-    if (raw && typeof raw === "object" && raw.searches && raw.pages) {
-      cacheData = raw as CacheData;
+    const raw: unknown = JSON.parse(readFileSync(CACHE_PATH, "utf8"));
+    if (isRecord(raw) && isRecord(raw.searches) && isRecord(raw.pages)) {
+      cacheData = raw as unknown as CacheData;
       return cacheData;
     }
   } catch {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "files": [
     "index.ts",
     "config.ts",
+    "cache.ts",
     "limits.generated.ts",
     "models.ts",
     "models.generated.ts",

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1,0 +1,87 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// cache.ts reads env at module load; re-import per test with an isolated path.
+async function freshCache() {
+  const dir = mkdtempSync(join(tmpdir(), "ollama-cache-"));
+  vi.stubEnv("PI_OLLAMA_SEARCH_CACHE_PATH", join(dir, "cache.json"));
+  vi.resetModules();
+  const mod = await import("../cache.ts");
+  return { mod, dir };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe("loadCache/saveCache", () => {
+  it("persists entries to disk and reloads them in a fresh module instance", async () => {
+    const { mod, dir } = await freshCache();
+    const c = mod.loadCache();
+    c.searches.k = {
+      ts: 1,
+      q: "q",
+      results: [{ title: "t", url: "u", content: "c" }],
+    };
+    c.pages["https://dead"] = { ts: 1, error: "HTTP 404" };
+    mod.saveCache();
+
+    vi.resetModules();
+    const mod2 = await import("../cache.ts");
+    const c2 = mod2.loadCache();
+    expect(c2.searches.k.results[0].title).toBe("t");
+    expect(c2.pages["https://dead"].error).toBe("HTTP 404");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("starts fresh when the cache file is missing or corrupt", async () => {
+    const { mod, dir } = await freshCache();
+    writeFileSync(join(dir, "cache.json"), "not json");
+    const c = mod.loadCache();
+    expect(c.searches).toEqual({});
+    expect(c.pages).toEqual({});
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("isFresh", () => {
+  it("accepts a fresh success entry", async () => {
+    const { mod } = await freshCache();
+    expect(mod.isFresh({ ts: Date.now() })).toBe(true);
+  });
+
+  it("accepts a fresh failure entry", async () => {
+    const { mod } = await freshCache();
+    expect(mod.isFresh({ ts: Date.now(), error: "boom" })).toBe(true);
+  });
+
+  it("rejects an expired success entry after the success TTL", async () => {
+    const { mod } = await freshCache();
+    expect(mod.isFresh({ ts: Date.now() - mod.CACHE_TTL_MS - 1000 })).toBe(false);
+  });
+
+  it("rejects an expired failure entry after the shorter failure TTL", async () => {
+    const { mod } = await freshCache();
+    expect(mod.isFresh({ ts: Date.now() - mod.FAIL_TTL_MS - 1000, error: "boom" })).toBe(false);
+  });
+
+  it("rejects a missing entry", async () => {
+    const { mod } = await freshCache();
+    expect(mod.isFresh(undefined)).toBe(false);
+  });
+});
+
+describe("searchCacheKey", () => {
+  it("is stable for the same query and max_results", async () => {
+    const { mod } = await freshCache();
+    expect(mod.searchCacheKey("q", 5)).toBe(mod.searchCacheKey("q", 5));
+  });
+
+  it("differs when max_results differs", async () => {
+    const { mod } = await freshCache();
+    expect(mod.searchCacheKey("q", 5)).not.toBe(mod.searchCacheKey("q", 10));
+  });
+});

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -21,12 +21,13 @@ describe("loadCache/saveCache", () => {
   it("persists entries to disk and reloads them in a fresh module instance", async () => {
     const { mod, dir } = await freshCache();
     const c = mod.loadCache();
+    const now = Date.now();
     c.searches.k = {
-      ts: 1,
+      ts: now,
       q: "q",
       results: [{ title: "t", url: "u", content: "c" }],
     };
-    c.pages["https://dead"] = { ts: 1, error: "HTTP 404" };
+    c.pages["https://dead"] = { ts: now, error: "HTTP 404" };
     mod.saveCache();
 
     vi.resetModules();
@@ -43,6 +44,23 @@ describe("loadCache/saveCache", () => {
     const c = mod.loadCache();
     expect(c.searches).toEqual({});
     expect(c.pages).toEqual({});
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("prunes expired entries on save", async () => {
+    const { mod, dir } = await freshCache();
+    const c = mod.loadCache();
+    c.searches.stale = { ts: Date.now() - mod.CACHE_TTL_MS - 1000, q: "q", results: [] };
+    c.searches.fresh = { ts: Date.now(), q: "q", results: [] };
+    c.pages["https://stale"] = { ts: Date.now() - mod.FAIL_TTL_MS - 1000, error: "HTTP 404" };
+    mod.saveCache();
+
+    vi.resetModules();
+    const mod2 = await import("../cache.ts");
+    const c2 = mod2.loadCache();
+    expect(c2.searches.stale).toBeUndefined();
+    expect(c2.searches.fresh).toBeDefined();
+    expect(c2.pages["https://stale"]).toBeUndefined();
     rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/test/web-tools-cache-paging.test.ts
+++ b/test/web-tools-cache-paging.test.ts
@@ -104,4 +104,26 @@ describe("web tool cache and paging", () => {
     await expect(execute("ollama_web_fetch", params)).rejects.toThrow("from cache");
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it("does not negative-cache auth failures and points at the API key", async () => {
+    const fetchMock = vi.fn(async () => new Response("unauthorized", { status: 401 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const { execute } = await setupTools();
+    const params = { url: "https://example.com/secret" };
+
+    await expect(execute("ollama_web_fetch", params)).rejects.toThrow("authentication error");
+    await expect(execute("ollama_web_fetch", params)).rejects.toThrow("OLLAMA_API_KEY");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not negative-cache rate-limit failures", async () => {
+    const fetchMock = vi.fn(async () => new Response("slow down", { status: 429 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const { execute } = await setupTools();
+    const params = { url: "https://example.com/busy" };
+
+    await expect(execute("ollama_web_fetch", params)).rejects.toThrow("rate limited");
+    await expect(execute("ollama_web_fetch", params)).rejects.toThrow("try again shortly");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/test/web-tools-cache-paging.test.ts
+++ b/test/web-tools-cache-paging.test.ts
@@ -126,4 +126,52 @@ describe("web tool cache and paging", () => {
     await expect(execute("ollama_web_fetch", params)).rejects.toThrow("try again shortly");
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
+
+  it("refresh=true bypasses the cached search and replaces the entry", async () => {
+    let version = 1;
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            results: [{ title: "Result", url: "https://example.com", content: `v${version}` }],
+          }),
+          { status: 200 },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { execute } = await setupTools();
+
+    expect(output(await execute("ollama_web_search", { query: "test" }))).toContain("v1");
+    version = 2;
+    const refreshed = output(await execute("ollama_web_search", { query: "test", refresh: true }));
+    expect(refreshed).toContain("v2");
+    expect(refreshed).toContain("# live query");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // The fresh result replaced the cache entry: a normal call now serves v2 from cache.
+    const cached = output(await execute("ollama_web_search", { query: "test" }));
+    expect(cached).toContain("v2");
+    expect(cached).toContain("# from cache");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("refresh=true forces a live retry of a cached failure", async () => {
+    const fetchMock = vi.fn(
+      async () => new Response(JSON.stringify({ title: "Back", content: "recovered", links: null }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { execute } = await setupTools();
+
+    // Seed a cached failure (404), then recover.
+    fetchMock.mockImplementationOnce(async () => new Response("not found", { status: 404 }));
+    const params = { url: "https://example.com/flaky" };
+    await expect(execute("ollama_web_fetch", params)).rejects.toThrow("live request failed");
+    await expect(execute("ollama_web_fetch", params)).rejects.toThrow("refresh=true");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const retried = output(await execute("ollama_web_fetch", { ...params, refresh: true }));
+    expect(retried).toContain("recovered");
+    expect(retried).toContain("# live query");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/test/web-tools-cache-paging.test.ts
+++ b/test/web-tools-cache-paging.test.ts
@@ -1,0 +1,107 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type RegisteredTool = {
+  name: string;
+  execute: (...args: any[]) => Promise<{ content: Array<{ type: string; text?: string }> }>;
+};
+
+const tempDirs: string[] = [];
+
+async function setupTools() {
+  const dir = mkdtempSync(join(tmpdir(), "ollama-web-tools-"));
+  tempDirs.push(dir);
+  vi.stubEnv("PI_OLLAMA_SEARCH_CACHE_PATH", join(dir, "cache.json"));
+  vi.stubEnv("PI_OLLAMA_SEARCH_SNIPPET_CHARS", "500");
+  vi.stubEnv("PI_OLLAMA_SEARCH_CHUNK_CHARS", "3000");
+  vi.resetModules();
+
+  const { registerWebFetchTool, registerWebSearchTool } = await import("../web-tools.ts");
+  const tools = new Map<string, RegisteredTool>();
+  const pi = { registerTool: (tool: RegisteredTool) => tools.set(tool.name, tool) };
+  registerWebSearchTool(pi as any);
+  registerWebFetchTool(pi as any);
+
+  const ctx = {
+    modelRegistry: { getApiKeyForProvider: vi.fn().mockResolvedValue("test-key") },
+  };
+  const execute = (name: string, params: Record<string, unknown>) =>
+    tools.get(name)!.execute("test-call", params, new AbortController().signal, undefined, ctx);
+
+  return { execute };
+}
+
+function output(result: { content: Array<{ type: string; text?: string }> }): string {
+  return result.content.find((part) => part.type === "text")?.text ?? "";
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  vi.resetModules();
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("web tool cache and paging", () => {
+  it("expands a cached search result without a second API call", async () => {
+    const fullContent = "x".repeat(600);
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ results: [{ title: "Result", url: "https://example.com", content: fullContent }] }),
+          { status: 200 },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { execute } = await setupTools();
+
+    const search = output(await execute("ollama_web_search", { query: "test" }));
+    expect(search).toContain("[truncated] Result");
+    expect(search).toContain("# live query");
+
+    const expanded = output(await execute("ollama_web_search", { query: "test", expand: 1 }));
+    expect(expanded).toContain(fullContent);
+    expect(expanded).toContain("# from cache");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads a cached page with offset/full without a second API call", async () => {
+    const pageContent = `${"a".repeat(3000)}${"b".repeat(4000)}`;
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ title: "Long page", content: pageContent, links: ["https://example.com/next"] }),
+          { status: 200 },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { execute } = await setupTools();
+
+    const firstPage = output(await execute("ollama_web_fetch", { url: "https://example.com" }));
+    expect(firstPage).toContain("Chars 1-3000 of 7000");
+    expect(firstPage).toContain("offset=3000");
+    expect(firstPage).toContain("# live query");
+
+    const remainder = output(
+      await execute("ollama_web_fetch", { url: "https://example.com", offset: 3000, full: true }),
+    );
+    expect(remainder).toContain("Chars 3001-7000 of 7000");
+    expect(remainder).toContain("b".repeat(4000));
+    expect(remainder).not.toContain("Continue:");
+    expect(remainder).toContain("# from cache");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("negative-caches a failed page fetch", async () => {
+    const fetchMock = vi.fn(async () => new Response("not found", { status: 404 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const { execute } = await setupTools();
+    const params = { url: "https://example.com/missing" };
+
+    await expect(execute("ollama_web_fetch", params)).rejects.toThrow("live request failed");
+    await expect(execute("ollama_web_fetch", params)).rejects.toThrow("from cache");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/utils.ts
+++ b/utils.ts
@@ -111,3 +111,9 @@ export function httpError(op: string, status: number, error?: string): never {
     `Ollama Cloud ${op} failed: unexpected response (status ${status}${error ? `: ${error}` : ""}). Try again shortly.`,
   );
 }
+
+/** Parse a positive-integer env var, falling back when unset or invalid (NaN, non-integer, <= 0). */
+export function envInt(name: string, fallback: number): number {
+  const value = Number(process.env[name]);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}

--- a/web-tools.ts
+++ b/web-tools.ts
@@ -29,7 +29,7 @@ import { type Component, Text, truncateToWidth } from "@earendil-works/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { isFresh, loadCache, type PageCacheEntry, type SearchResult, saveCache, searchCacheKey } from "./cache.ts";
 import { OLLAMA_BASE } from "./models.ts";
-import { fetchJsonWithTimeout, getCloudApiKey, httpError } from "./utils.ts";
+import { envInt, fetchJsonWithTimeout, getCloudApiKey, httpError } from "./utils.ts";
 
 // --- Types ---
 
@@ -52,8 +52,8 @@ interface FetchResponse {
 const WEB_TOOLS_TIMEOUT_MS = 15000;
 // Search snippets and fetch chunks are capped so a single call never floods the
 // context window; the agent pages through long pages with offset/full.
-const SNIPPET_LIMIT = Number(process.env.PI_OLLAMA_SEARCH_SNIPPET_CHARS ?? 500);
-const READ_CHUNK = Number(process.env.PI_OLLAMA_SEARCH_CHUNK_CHARS ?? 3000);
+const SNIPPET_LIMIT = envInt("PI_OLLAMA_SEARCH_SNIPPET_CHARS", 500);
+const READ_CHUNK = envInt("PI_OLLAMA_SEARCH_CHUNK_CHARS", 3000);
 
 /** Throw a no-API-key error. */
 function noApiKeyError(): never {
@@ -143,18 +143,27 @@ export function isFetchResponse(data: unknown): data is FetchResponse {
 
 /** Build a failure message with likely causes and next steps (thrown, per the AgentToolResult contract). */
 function fetchFailureMessage(url: string, entry: PageCacheEntry, live: boolean): string {
-  const cause = url.toLowerCase().includes("linkedin")
-    ? "LinkedIn requires login / blocks scrapers"
-    : "anti-bot / login wall, JS-rendered page, or malformed URL";
-  return [
+  const lines = [
     `Ollama Cloud fetch failed: ${url}`,
     `API error: ${entry.error}`,
     live
       ? "Status: live request failed (not cached)"
       : "Status: from cache (failure cached; retry will not re-call the API)",
-    `Likely cause: ${cause}`,
-    "Suggestion: 1) use ollama_web_search for the site/topic; 2) check the URL; 3) retrying with offset/full will also fail — don't.",
-  ].join("\n");
+  ];
+  if (entry.status === 401 || entry.status === 403) {
+    lines.push(
+      "Likely cause: authentication error.",
+      "Suggestion: check your API key in OLLAMA_API_KEY or auth.json, then retry (auth failures are not cached).",
+    );
+  } else if (entry.status === 429) {
+    lines.push("Likely cause: rate limited.", "Suggestion: try again shortly (rate-limit failures are not cached).");
+  } else {
+    lines.push(
+      "Likely cause: anti-bot / login wall, JS-rendered page, or malformed URL.",
+      "Suggestion: 1) use ollama_web_search for the site/topic; 2) check the URL; 3) retrying with offset/full will also fail — don't.",
+    );
+  }
+  return lines.join("\n");
 }
 
 // --- Registrations ---
@@ -342,7 +351,7 @@ export function registerWebFetchTool(pi: ExtensionAPI) {
         );
 
         if (!res.ok) {
-          entry = { ts: Date.now(), error: `HTTP ${res.status}: ${res.error ?? "unknown error"}` };
+          entry = { ts: Date.now(), status: res.status, error: `HTTP ${res.status}: ${res.error ?? "unknown error"}` };
         } else if (!isFetchResponse(res.data)) {
           entry = { ts: Date.now(), error: "unexpected response shape from the API" };
         } else {
@@ -353,15 +362,19 @@ export function registerWebFetchTool(pi: ExtensionAPI) {
             links: res.data.links,
           };
         }
-        cache.pages[params.url] = entry;
-        saveCache();
+        // Auth and rate-limit failures are not negative-cached: a fixed key or
+        // an expired rate-limit window should let the next retry through.
+        if (!(entry.status === 401 || entry.status === 403 || entry.status === 429)) {
+          cache.pages[params.url] = entry;
+          saveCache();
+        }
       }
 
       if (entry.error) {
         throw new Error(fetchFailureMessage(params.url, entry, live));
       }
 
-      const content = entry.content!;
+      const content = entry.content ?? "";
       const total = content.length;
       const start = params.offset ?? 0;
       const end = params.full ? total : Math.min(start + READ_CHUNK, total);

--- a/web-tools.ts
+++ b/web-tools.ts
@@ -148,7 +148,7 @@ function fetchFailureMessage(url: string, entry: PageCacheEntry, live: boolean):
     `API error: ${entry.error}`,
     live
       ? "Status: live request failed (not cached)"
-      : "Status: from cache (failure cached; retry will not re-call the API)",
+      : "Status: from cache (failure cached; pass refresh=true to force a live retry)",
   ];
   if (entry.status === 401 || entry.status === 403) {
     lines.push(
@@ -160,7 +160,7 @@ function fetchFailureMessage(url: string, entry: PageCacheEntry, live: boolean):
   } else {
     lines.push(
       "Likely cause: anti-bot / login wall, JS-rendered page, or malformed URL.",
-      "Suggestion: 1) use ollama_web_search for the site/topic; 2) check the URL; 3) retrying with offset/full will also fail — don't.",
+      "Suggestion: 1) use ollama_web_search for the site/topic; 2) check the URL; 3) retrying with offset/full will also fail — use refresh=true only if you believe the failure was transient.",
     );
   }
   return lines.join("\n");
@@ -177,6 +177,7 @@ export function registerWebSearchTool(pi: ExtensionAPI) {
       "Returns up to 5 results (title, URL, 500-char snippet; [truncated] means the source is longer — " +
       "pass expand=<index> to get that result's full content from the cached search, 0 extra API calls). " +
       "Results are cached for 24h: the same query within that window costs 0 API calls. " +
+      "Pass refresh=true to bypass the cache and re-call the API (e.g. results look stale). " +
       "Requires an Ollama Cloud API key.",
     parameters: Type.Object({
       query: Type.String({ description: "The search query to execute" }),
@@ -186,6 +187,13 @@ export function registerWebSearchTool(pi: ExtensionAPI) {
           default: 5,
           minimum: 1,
           maximum: 10,
+        }),
+      ),
+      refresh: Type.Optional(
+        Type.Boolean({
+          description:
+            "Bypass the cached search and re-call the API (default: false). The fresh result replaces the cache entry.",
+          default: false,
         }),
       ),
       expand: Type.Optional(
@@ -210,7 +218,7 @@ export function registerWebSearchTool(pi: ExtensionAPI) {
       let live = false;
       let results: SearchResult[];
 
-      if (isFresh(cached)) {
+      if (!params.refresh && isFresh(cached)) {
         results = cached!.results;
       } else {
         live = true;
@@ -307,7 +315,8 @@ export function registerWebFetchTool(pi: ExtensionAPI) {
       "Returns the page title, a 3000-char slice of the content, and links. Pages are cached for 24h. " +
       "Pass offset=N to continue reading from char N (the output tells you the next offset), or " +
       "full=true to get all remaining content from offset in one call. A failed URL is cached for 15 min " +
-      "— retrying it within that window costs 0 API calls and fails the same way. Requires an Ollama Cloud API key.",
+      "— retrying it within that window costs 0 API calls and fails the same way; pass refresh=true to " +
+      "force a live retry. Requires an Ollama Cloud API key.",
     parameters: Type.Object({
       url: Type.String({ description: "URL to fetch and extract content from", format: "uri" }),
       offset: Type.Optional(
@@ -323,6 +332,13 @@ export function registerWebFetchTool(pi: ExtensionAPI) {
           default: false,
         }),
       ),
+      refresh: Type.Optional(
+        Type.Boolean({
+          description:
+            "Bypass the cached page (or cached failure) and re-call the API (default: false). The fresh result replaces the cache entry.",
+          default: false,
+        }),
+      ),
     }),
     async execute(_toolCallId, params, signal, _onUpdate, ctx) {
       const apiKey = await getCloudApiKey(ctx);
@@ -334,7 +350,7 @@ export function registerWebFetchTool(pi: ExtensionAPI) {
       let entry = cache.pages[params.url];
       let live = false;
 
-      if (!isFresh(entry)) {
+      if (params.refresh || !isFresh(entry)) {
         live = true;
         const res = await fetchJsonWithTimeout<FetchResponse>(
           `${OLLAMA_BASE}/api/web_fetch`,

--- a/web-tools.ts
+++ b/web-tools.ts
@@ -6,6 +6,7 @@
  *   - pi-coding-agent - ExtensionAPI, ExtensionContext, keyHint, truncateToVisualLines
  *   - pi-tui          - Text, truncateToWidth
  *   - utils.ts        - fetchJsonWithTimeout
+ *   - cache.ts        - disk-backed cache (24h success / 15min failure TTL)
  * Does NOT depend on provider registration or model fetching internals.
  *
  * API key resolution: each tool's execute() receives an ExtensionContext whose
@@ -26,6 +27,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { type Component, Text, truncateToWidth } from "@earendil-works/pi-tui";
 import { Type } from "@sinclair/typebox";
+import { isFresh, loadCache, type PageCacheEntry, type SearchResult, saveCache, searchCacheKey } from "./cache.ts";
 import { OLLAMA_BASE } from "./models.ts";
 import { fetchJsonWithTimeout, getCloudApiKey, httpError } from "./utils.ts";
 
@@ -48,6 +50,10 @@ interface FetchResponse {
 // --- Helpers ---
 
 const WEB_TOOLS_TIMEOUT_MS = 15000;
+// Search snippets and fetch chunks are capped so a single call never floods the
+// context window; the agent pages through long pages with offset/full.
+const SNIPPET_LIMIT = Number(process.env.PI_OLLAMA_SEARCH_SNIPPET_CHARS ?? 500);
+const READ_CHUNK = Number(process.env.PI_OLLAMA_SEARCH_CHUNK_CHARS ?? 3000);
 
 /** Throw a no-API-key error. */
 function noApiKeyError(): never {
@@ -135,6 +141,22 @@ export function isFetchResponse(data: unknown): data is FetchResponse {
   );
 }
 
+/** Build a failure message with likely causes and next steps (thrown, per the AgentToolResult contract). */
+function fetchFailureMessage(url: string, entry: PageCacheEntry, live: boolean): string {
+  const cause = url.toLowerCase().includes("linkedin")
+    ? "LinkedIn requires login / blocks scrapers"
+    : "anti-bot / login wall, JS-rendered page, or malformed URL";
+  return [
+    `Ollama Cloud fetch failed: ${url}`,
+    `API error: ${entry.error}`,
+    live
+      ? "Status: live request failed (not cached)"
+      : "Status: from cache (failure cached; retry will not re-call the API)",
+    `Likely cause: ${cause}`,
+    "Suggestion: 1) use ollama_web_search for the site/topic; 2) check the URL; 3) retrying with offset/full will also fail — don't.",
+  ].join("\n");
+}
+
 // --- Registrations ---
 
 export function registerWebSearchTool(pi: ExtensionAPI) {
@@ -143,7 +165,9 @@ export function registerWebSearchTool(pi: ExtensionAPI) {
     label: "Ollama Web Search",
     description:
       "Search the web for real-time information using Ollama Cloud's web search API. " +
-      "Returns relevant results with titles, URLs, and content snippets. " +
+      "Returns up to 5 results (title, URL, 500-char snippet; [truncated] means the source is longer — " +
+      "pass expand=<index> to get that result's full content from the cached search, 0 extra API calls). " +
+      "Results are cached for 24h: the same query within that window costs 0 API calls. " +
       "Requires an Ollama Cloud API key.",
     parameters: Type.Object({
       query: Type.String({ description: "The search query to execute" }),
@@ -155,6 +179,14 @@ export function registerWebSearchTool(pi: ExtensionAPI) {
           maximum: 10,
         }),
       ),
+      expand: Type.Optional(
+        Type.Integer({
+          description:
+            "Return the full content of this result (1-based index) instead of snippets. " +
+            "Served from the cached search — 0 API calls if the query was searched recently.",
+          minimum: 1,
+        }),
+      ),
     }),
     async execute(_toolCallId, params, signal, _onUpdate, ctx) {
       const apiKey = await getCloudApiKey(ctx);
@@ -162,37 +194,91 @@ export function registerWebSearchTool(pi: ExtensionAPI) {
         noApiKeyError();
       }
 
-      const res = await fetchJsonWithTimeout<SearchResponse>(
-        `${OLLAMA_BASE}/api/web_search`,
-        {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${apiKey}`,
-            "Content-Type": "application/json",
+      const maxResults = params.max_results ?? 5;
+      const cache = loadCache();
+      const key = searchCacheKey(params.query, maxResults);
+      const cached = cache.searches[key];
+      let live = false;
+      let results: SearchResult[];
+
+      if (isFresh(cached)) {
+        results = cached!.results;
+      } else {
+        live = true;
+        const res = await fetchJsonWithTimeout<SearchResponse>(
+          `${OLLAMA_BASE}/api/web_search`,
+          {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${apiKey}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              query: params.query,
+              max_results: maxResults,
+            }),
           },
-          body: JSON.stringify({
-            query: params.query,
-            max_results: params.max_results ?? 5,
-          }),
-        },
-        WEB_TOOLS_TIMEOUT_MS,
-        signal,
-      );
+          WEB_TOOLS_TIMEOUT_MS,
+          signal,
+        );
 
-      if (!res.ok) {
-        httpError("search", res.status, res.error);
-      }
-      if (!isSearchResponse(res.data)) {
-        throw new Error("Web search failed: unexpected response shape from the API.");
+        if (!res.ok) {
+          httpError("search", res.status, res.error);
+        }
+        if (!isSearchResponse(res.data)) {
+          throw new Error("Web search failed: unexpected response shape from the API.");
+        }
+
+        results = res.data.results.map((r) => ({
+          title: r.title,
+          url: r.url,
+          content: r.content,
+        }));
+        cache.searches[key] = { ts: Date.now(), q: params.query, results };
+        saveCache();
       }
 
-      const formatted = res.data.results
-        .map((r, i) => `${i + 1}. ${r.title}\n   URL: ${r.url}\n   ${r.content}`)
+      // Expand mode: return the full content of one result from the cached search.
+      if (params.expand !== undefined) {
+        const idx = params.expand;
+        if (idx < 1 || idx > results.length) {
+          throw new Error(
+            `Web search expand: index ${idx} out of range (this search has ${results.length} results). ` +
+              "Use ollama_web_fetch to read a specific URL instead.",
+          );
+        }
+        const r = results[idx - 1];
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Result ${idx} of "${params.query}" (full content, ${r.content.length} chars):\n\n${r.content}\n\n${live ? "# live query" : "# from cache"}`,
+            },
+          ],
+          details: { results: [r] },
+        };
+      }
+
+      const formatted = results
+        .map((r, i) => {
+          const truncated = r.content.length > SNIPPET_LIMIT;
+          return `${i + 1}. ${truncated ? "[truncated]" : "[complete]"} ${r.title}\n   URL: ${r.url}\n   ${r.content.slice(0, SNIPPET_LIMIT)}`;
+        })
         .join("\n\n");
 
+      const hasTruncated = results.some((r) => r.content.length > SNIPPET_LIMIT);
+      const expandHint = hasTruncated
+        ? `\n\nExpand: call ollama_web_search(query="${params.query}", expand=<index>) to read a [truncated] result in full — 0 extra API calls.`
+        : "";
+
       return {
-        content: [{ type: "text", text: formatted || "No results found." }],
-        details: { results: res.data.results },
+        content: [
+          {
+            type: "text",
+            text: `${formatted || "No results found."}${expandHint}\n\n${live ? "# live query" : "# from cache"}`,
+          },
+        ],
+        details: { results },
       };
     },
     renderCall(args, theme, _context) {
@@ -209,10 +295,25 @@ export function registerWebFetchTool(pi: ExtensionAPI) {
     label: "Ollama Web Fetch",
     description:
       "Fetch and extract text content from a web page URL using Ollama Cloud's web fetch API. " +
-      "Returns the page title, main content, and links found on the page. " +
-      "Requires an Ollama Cloud API key.",
+      "Returns the page title, a 3000-char slice of the content, and links. Pages are cached for 24h. " +
+      "Pass offset=N to continue reading from char N (the output tells you the next offset), or " +
+      "full=true to get all remaining content from offset in one call. A failed URL is cached for 15 min " +
+      "— retrying it within that window costs 0 API calls and fails the same way. Requires an Ollama Cloud API key.",
     parameters: Type.Object({
       url: Type.String({ description: "URL to fetch and extract content from", format: "uri" }),
+      offset: Type.Optional(
+        Type.Integer({
+          description: "Start reading from this character index (default: 0)",
+          default: 0,
+          minimum: 0,
+        }),
+      ),
+      full: Type.Optional(
+        Type.Boolean({
+          description: "Return all remaining content from offset in one call (default: false)",
+          default: false,
+        }),
+      ),
     }),
     async execute(_toolCallId, params, signal, _onUpdate, ctx) {
       const apiKey = await getCloudApiKey(ctx);
@@ -220,41 +321,70 @@ export function registerWebFetchTool(pi: ExtensionAPI) {
         noApiKeyError();
       }
 
-      const res = await fetchJsonWithTimeout<FetchResponse>(
-        `${OLLAMA_BASE}/api/web_fetch`,
-        {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${apiKey}`,
-            "Content-Type": "application/json",
+      const cache = loadCache();
+      let entry = cache.pages[params.url];
+      let live = false;
+
+      if (!isFresh(entry)) {
+        live = true;
+        const res = await fetchJsonWithTimeout<FetchResponse>(
+          `${OLLAMA_BASE}/api/web_fetch`,
+          {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${apiKey}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ url: params.url }),
           },
-          body: JSON.stringify({ url: params.url }),
-        },
-        WEB_TOOLS_TIMEOUT_MS,
-        signal,
-      );
+          WEB_TOOLS_TIMEOUT_MS,
+          signal,
+        );
 
-      if (!res.ok) {
-        httpError("fetch", res.status, res.error);
-      }
-      if (!isFetchResponse(res.data)) {
-        throw new Error("Web fetch failed: unexpected response shape from the API.");
+        if (!res.ok) {
+          entry = { ts: Date.now(), error: `HTTP ${res.status}: ${res.error ?? "unknown error"}` };
+        } else if (!isFetchResponse(res.data)) {
+          entry = { ts: Date.now(), error: "unexpected response shape from the API" };
+        } else {
+          entry = {
+            ts: Date.now(),
+            title: res.data.title,
+            content: res.data.content,
+            links: res.data.links,
+          };
+        }
+        cache.pages[params.url] = entry;
+        saveCache();
       }
 
-      const data = res.data;
-      const formatted = [
-        `Title: ${data.title}`,
-        "",
-        "Content:",
-        data.content,
-        "",
-        `Links found: ${data.links?.length ?? 0}`,
-        ...(data.links?.slice(0, 10).map((l) => `  - ${l}`) ?? []),
-      ].join("\n");
+      if (entry.error) {
+        throw new Error(fetchFailureMessage(params.url, entry, live));
+      }
+
+      const content = entry.content!;
+      const total = content.length;
+      const start = params.offset ?? 0;
+      const end = params.full ? total : Math.min(start + READ_CHUNK, total);
+      const lines = [
+        `Title: ${entry.title} (${total} chars total)`,
+        start >= total
+          ? "Already at the end, no more content."
+          : `Chars ${start + 1}-${end} of ${total}${end < total ? ` (${total - end} remaining)` : ""}:`,
+        content.slice(start, end),
+      ];
+      if (!params.full && end < total) {
+        lines.push(`\nContinue: call ollama_web_fetch(url="${params.url}", offset=${end})`);
+      }
+      if ((params.offset ?? 0) === 0 && !params.full) {
+        const links = entry.links ?? [];
+        lines.push(`\nLinks (${links.length}):`);
+        lines.push(...links.slice(0, 10).map((l) => `  - ${l}`));
+      }
+      lines.push(live ? "# live query" : "# from cache");
 
       return {
-        content: [{ type: "text", text: formatted }],
-        details: { title: data.title, content: data.content, links: data.links },
+        content: [{ type: "text", text: lines.join("\n") }],
+        details: { title: entry.title, totalChars: total, links: entry.links },
       };
     },
     renderCall(args, theme, _context) {


### PR DESCRIPTION
### Problem

Every call re-fetches the API and dumps unbounded content:

```
# Before — repeat search: 1 API call every time
ollama_web_search("pi coding agent")   → full content of all 5 results dumped

# Before — fetch: entire page in one shot, no way to read incrementally
ollama_web_fetch("https://pi.dev/")     → 4323 chars at once (pages can be 30k+)

# Before — dead page: bare error, retry re-calls the API
ollama_web_fetch("https://linkedin.com/...") → Error: fetch failed
```

### After

```
# Search: 500-char snippets, marked, cached 24h
ollama_web_search("pi coding agent")
→ 1. [truncated] Pi Coding Agent
     URL: https://pi.dev/
     <500-char snippet>
   2. [truncated] ...
   3. [complete] ...

   Expand: call ollama_web_search(query="pi coding agent", expand=<index>) to read a [truncated] result in full — 0 extra API calls.

   # from cache

# Expand a truncated result — from cache, 0 extra API calls
ollama_web_search("pi coding agent", expand=1)
→ Result 1 of "pi coding agent" (full content, 4323 chars):
   <full content>
   # from cache

# Fetch: 3000-char chunks, paged
ollama_web_fetch("https://pi.dev/")
→ Title: Pi Coding Agent (4323 chars total)
  Chars 1-3000 of 4323 (1323 remaining):
  <first 3000 chars>
  Continue: call ollama_web_fetch(url="https://pi.dev/", offset=3000)
  # live query

ollama_web_fetch("https://pi.dev/", offset=3000)   # next chunk, from cache, 0 API calls
ollama_web_fetch("https://pi.dev/", full=true)     # all remaining in one call

# Dead page: diagnostic + negative cache (15 min), retry costs 0 API calls
ollama_web_fetch("https://linkedin.com/company/xxx")
→ Ollama Cloud fetch failed: https://linkedin.com/company/xxx
  API error: HTTP 404: not found
  Likely cause: LinkedIn requires login / blocks scrapers
  Suggestion: 1) use ollama_web_search for the site/topic; 2) check the URL; 3) retrying with offset/full will also fail — don't.
```

### What changed

- **`ollama_web_search`**: snippets truncated to 500 chars with `[truncated]`/`[complete]` markers; full content of each result cached; new `expand=<index>` returns it with 0 extra API calls; results cached 24h; `# live query`/`# from cache` marker + `Expand:` hint in output.
- **`ollama_web_fetch`**: new `offset=N`/`full=true` params for paged reading (3000-char chunks, `Continue:` hint); pages cached 24h; failures negative-cached 15 min and throw a diagnostic instead of a bare error.
- **`cache.ts`** (new): pure-Node disk cache at `~/.cache/pi-ollama-cloud/cache.json`.

### Tuning

| Env var | Default | Meaning |
|---|---|---|
| `OLLAMA_SEARCH_TTL_HOURS` | `24` | Success cache TTL |
| `OLLAMA_SEARCH_FAIL_TTL_MINUTES` | `15` | Failure (negative) cache TTL |
| `OLLAMA_SEARCH_CACHE_PATH` | `~/.cache/pi-ollama-cloud/cache.json` | Cache file location |
| `OLLAMA_SEARCH_SNIPPET_CHARS` | `500` | Search snippet length |
| `OLLAMA_SEARCH_CHUNK_CHARS` | `3000` | Fetch chunk size |

### Tests

`npm run check` clean; `npm test` 119 pass (9 new `cache.test.ts`: persistence, corrupt-file recovery, TTL expiry, key stability).
