### PR TITLE
fix(usage): accept monthly and session/weekly /api/usage shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Fix `/ollama-cloud-usage` and the usage status bar failing with "unexpected response shape" after the undocumented `/api/usage` endpoint flipped back from a single `limits.monthly` bucket to `limits.session` plus `limits.weekly` (as served before 2026-09-03 and again as of 2026-09-07). All three buckets are now optional; whichever are present are displayed.
+
 ## [0.10.0] - 2026-09-03
 
 - **Breaking:** Adapt to the changed `/api/usage` response shape. The endpoint now returns a single `limits.monthly` bucket (replacing `limits.session` and `limits.weekly`) and adds an `activity.models` array. `UsageData`, `isUsageResponse`, `formatUsage`, and `formatUsageStatusColored` now read the monthly limit; the status bar shows a single `30d` segment instead of `5h`/`7d`.

--- a/README.md
+++ b/README.md
@@ -172,13 +172,15 @@ Both tools use the same Ollama Cloud API key configured for the provider. No loc
 | Command | Description |
 |---|---|
 | `/ollama-webtools [on\|off\|enable\|disable]` | Enable or disable the `ollama_web_search` and `ollama_web_fetch` tools. Toggles if no argument given. |
-| `/ollama-cloud-usage` | Show Ollama Cloud monthly usage limits, per-model request counts, and the 4-week activity cost. |
+| `/ollama-cloud-usage` | Show Ollama Cloud usage limits (one section per limit bucket the API reports), per-model request counts, and the 4-week activity cost. |
 | `/ollama-usage-status [on\|off\|enable\|disable]` | Enable or disable the footer usage status bar. Toggles if no argument given. |
 
 ## Usage status bar
 
 While an `ollama-cloud` model is the active provider, the footer shows a compact
-live usage readout (`30d ▕███░░░░░░░▏ 34%`) that refreshes
+live usage readout with one segment per limit bucket the API reports
+(`5h ▕███░░░░░░░▏ 34% 7d ▕█░░░░░░░░░▏ 7%`, or a single `30d` segment when the
+API serves the monthly shape) that refreshes
 every 5 minutes and after each agent turn (but no more often than every 5 minutes). It is colored by how close
 it is to the cap: green below 60%, yellow at 60-79%, red at 80%+. It reads the
 same undocumented `/api/usage` endpoint as `/ollama-cloud-usage` and clears

--- a/index.ts
+++ b/index.ts
@@ -134,7 +134,7 @@ export default async function (pi: ExtensionAPI) {
   // --- Usage Command ---
 
   pi.registerCommand("ollama-cloud-usage", {
-    description: "Show Ollama Cloud monthly usage limits.",
+    description: "Show Ollama Cloud usage limits.",
     handler: async (_args, ctx) => {
       const apiKey = await getCloudApiKey(ctx);
       if (!apiKey) {
@@ -152,7 +152,7 @@ export default async function (pi: ExtensionAPI) {
 
   // --- Usage Status Bar ---
 
-  // Footer status showing live monthly usage while ollama-cloud is the
+  // Footer status showing live usage while ollama-cloud is the
   // active provider. Refreshes on a 5-minute timer; agent_end also triggers a
   // refresh but is throttled to the same cooldown so a turn never hammers the
   // undocumented /api/usage endpoint. The quota-bar concept is inspired by

--- a/test/usage.test.ts
+++ b/test/usage.test.ts
@@ -10,7 +10,7 @@ afterEach(() => {
   globalThis.fetch = originalFetch;
 });
 
-/** A minimal valid /api/usage response. */
+/** A minimal valid /api/usage response with a single monthly bucket. */
 function usageResponse(
   overrides: {
     monthlyUsage?: number;
@@ -26,6 +26,24 @@ function usageResponse(
       },
     },
     activity: overrides.activity ?? { cost: "0.00000", period: { type: "last_4_weeks" } },
+  };
+}
+
+/** A minimal valid /api/usage response with session and weekly buckets. */
+function sessionWeeklyResponse(
+  overrides: {
+    sessionUsage?: number;
+    weeklyUsage?: number;
+    models?: Array<{ name: string; request_count: number }>;
+  } = {},
+) {
+  const models = overrides.models ?? [{ name: "model-a", request_count: 2 }];
+  return {
+    limits: {
+      session: { usage: overrides.sessionUsage ?? 0.4, models },
+      weekly: { usage: overrides.weeklyUsage ?? 0.07, models },
+    },
+    activity: { cost: "0.00000", period: { type: "last_4_weeks" } },
   };
 }
 
@@ -72,17 +90,27 @@ describe("isUsageLimit", () => {
 // ============================================================================
 
 describe("isUsageResponse", () => {
-  it("accepts a valid response", () => {
+  it("accepts a monthly-only response", () => {
     expect(isUsageResponse(usageResponse())).toBe(true);
+  });
+
+  it("accepts a session plus weekly response", () => {
+    expect(isUsageResponse(sessionWeeklyResponse())).toBe(true);
   });
 
   it("rejects a response missing limits", () => {
     expect(isUsageResponse({})).toBe(false);
   });
 
-  it("rejects a response missing the monthly limit", () => {
+  it("rejects a monthly-only response missing the monthly limit", () => {
     const data = usageResponse();
     delete (data.limits as { monthly?: unknown }).monthly;
+    expect(isUsageResponse(data)).toBe(false);
+  });
+
+  it("rejects a session response missing the weekly limit", () => {
+    const data = sessionWeeklyResponse();
+    delete (data.limits as { weekly?: unknown }).weekly;
     expect(isUsageResponse(data)).toBe(false);
   });
 
@@ -106,7 +134,14 @@ describe("fetchUsage", () => {
   it("returns parsed usage on a 200 response", async () => {
     mockFetch(200, usageResponse());
     const data = await fetchUsage("key");
-    expect(data.limits.monthly.usage).toBe(0.34);
+    expect(data.limits.monthly?.usage).toBe(0.34);
+  });
+
+  it("returns parsed session and weekly usage on a 200 response", async () => {
+    mockFetch(200, sessionWeeklyResponse());
+    const data = await fetchUsage("key");
+    expect(data.limits.session?.usage).toBe(0.4);
+    expect(data.limits.weekly?.usage).toBe(0.07);
   });
 
   it("throws an auth error on 401", async () => {
@@ -151,6 +186,13 @@ describe("formatUsage", () => {
     expect(out).toContain("- model-a: 2 requests");
   });
 
+  it("formats session and weekly percentages and per-model counts", () => {
+    const out = formatUsage(sessionWeeklyResponse());
+    expect(out).toContain("Session (5h): 40%");
+    expect(out).toContain("Weekly (7d): 7%");
+    expect(out).toContain("- model-a: 2 requests");
+  });
+
   it("includes the activity cost when present", () => {
     const out = formatUsage(usageResponse());
     expect(out).toContain("Activity (4wk): $0.00000");
@@ -179,6 +221,12 @@ const fakeTheme = {
 describe("formatUsageStatusColored", () => {
   it("formats a compact one-line status with a quota bar", () => {
     expect(formatUsageStatusColored(fakeTheme, usageResponse())).toBe("<success>30d ▕███░░░░░░░▏ 34%</success>");
+  });
+
+  it("renders one segment per bucket for a session plus weekly response", () => {
+    expect(formatUsageStatusColored(fakeTheme, sessionWeeklyResponse())).toBe(
+      "<success>5h ▕████░░░░░░▏ 40%</success> <success>7d ▕░░░░░░░░░░▏ 7%</success>",
+    );
   });
 
   it("colors a segment red at 80% or above", () => {

--- a/usage.ts
+++ b/usage.ts
@@ -11,6 +11,12 @@
  * fetch degrades gracefully: distinct HTTP statuses map to distinct
  * user-facing errors, and a malformed body raises a clear error rather than
  * crashing.
+ *
+ * The response shape has flipped twice: through 2026-09-02 it carried
+ * limits.session and limits.weekly, on 2026-09-03 it switched to a single
+ * limits.monthly bucket (0.10.0 adapted to that), and by 2026-09-07 it
+ * returned session and weekly again. All three buckets are therefore optional
+ * and whichever are present are displayed.
  */
 
 import type { Theme } from "@earendil-works/pi-coding-agent";
@@ -43,7 +49,12 @@ export interface UsageActivity {
 
 export interface UsageData {
   limits: {
-    monthly: UsageLimit;
+    /** Monthly (30d) bucket, served by the API between 2026-09-03 and 2026-09-07. */
+    monthly?: UsageLimit;
+    /** Session (5h) bucket, served before 2026-09-03 and again as of 2026-09-07. */
+    session?: UsageLimit;
+    /** Weekly (7d) bucket, served before 2026-09-03 and again as of 2026-09-07. */
+    weekly?: UsageLimit;
   };
   activity?: UsageActivity;
 }
@@ -71,11 +82,15 @@ export function isUsageLimit(data: unknown): data is UsageLimit {
   );
 }
 
-/** Validate a parsed /api/usage response: must have a monthly limit. */
+/**
+ * Validate a parsed /api/usage response: needs a monthly limit or both a
+ * session and a weekly limit.
+ */
 export function isUsageResponse(data: unknown): data is UsageData {
   if (data == null || typeof data !== "object") return false;
   const d = data as UsageData;
-  return d.limits != null && typeof d.limits === "object" && isUsageLimit(d.limits.monthly);
+  if (d.limits == null || typeof d.limits !== "object") return false;
+  return isUsageLimit(d.limits.monthly) || (isUsageLimit(d.limits.session) && isUsageLimit(d.limits.weekly));
 }
 
 // --- Fetch ---
@@ -121,14 +136,30 @@ function usagePercent(usage: number): number {
   return Math.min(Math.max(Math.round(usage * 100), 0), 100);
 }
 
+/** The limit buckets present in a response, in display order. */
+function limitSegments(data: UsageData): Array<{ label: string; short: string; limit: UsageLimit }> {
+  const segs: Array<{ label: string; short: string; limit: UsageLimit }> = [];
+  if (data.limits.session != null) {
+    segs.push({ label: "Session (5h)", short: "5h", limit: data.limits.session });
+  }
+  if (data.limits.weekly != null) {
+    segs.push({ label: "Weekly (7d)", short: "7d", limit: data.limits.weekly });
+  }
+  if (data.limits.monthly != null) {
+    segs.push({ label: "Monthly (30d)", short: "30d", limit: data.limits.monthly });
+  }
+  return segs;
+}
+
 /** Format usage for the /ollama-cloud-usage command output. */
 export function formatUsage(data: UsageData): string {
   const lines: string[] = ["Ollama Cloud usage:"];
 
-  const monthlyPct = usagePercent(data.limits.monthly.usage);
-  lines.push(`  Monthly (30d): ${monthlyPct}%`);
-  for (const m of data.limits.monthly.models) {
-    lines.push(`    - ${m.name}: ${m.request_count} request${m.request_count === 1 ? "" : "s"}`);
+  for (const seg of limitSegments(data)) {
+    lines.push(`  ${seg.label}: ${usagePercent(seg.limit.usage)}%`);
+    for (const m of seg.limit.models) {
+      lines.push(`    - ${m.name}: ${m.request_count} request${m.request_count === 1 ? "" : "s"}`);
+    }
   }
 
   if (typeof data.activity?.cost === "string") {
@@ -151,11 +182,13 @@ function colorSegment(theme: Theme, label: string, pct: number): string {
 }
 
 /**
- * Compact one-line usage for the footer status bar, colored by usage level.
- * The endpoint exposes a monthly reset period but not an exact timestamp, so
- * the color reflects the usage fraction rather than pace.
+ * Compact one-line usage for the footer status bar, colored by usage level,
+ * with one segment per limit bucket present in the response (5h and 7d, or
+ * 30d when the API serves the monthly shape). The color reflects the usage
+ * fraction rather than pace because the bucket periods differ per shape.
  */
 export function formatUsageStatusColored(theme: Theme, data: UsageData): string {
-  const monthly = usagePercent(data.limits.monthly.usage);
-  return colorSegment(theme, "30d", monthly);
+  return limitSegments(data)
+    .map((seg) => colorSegment(theme, seg.short, usagePercent(seg.limit.usage)))
+    .join(" ");
 }


### PR DESCRIPTION
0.10.0 adapted `isUsageResponse` to a single `limits.monthly` bucket (#53). As of 2026-09-07 the undocumented `/api/usage` endpoint serves `limits.session` + `limits.weekly` again, so `/ollama-cloud-usage` and the usage status bar fail with "unexpected response shape".

The shape has flipped twice in a week, so this accepts both: all three buckets (`monthly`, `session`, `weekly`) are optional in `UsageData` and whichever are present are rendered by `formatUsage` and `formatUsageStatusColored`.

Noted the repo rule against keeping backward compatibility. I kept `monthly` support deliberately, since the endpoint is undocumented and already flipped once; happy to drop it in favor of strict `session`+`weekly` matching if you prefer.

Changes:
- `usage.ts`: `isUsageResponse` requires `monthly` or `session`+`weekly`; formatters render one segment per present bucket (`5h`/`7d`/`30d`)
- `test/usage.test.ts`: fixtures and cases for both shapes
- `index.ts`: command description no longer hardcodes "monthly"
- `README.md` + `CHANGELOG.md`: updated to match behavior